### PR TITLE
NO-ISSUE: Adjust filter on job name

### DIFF
--- a/src/prowjobsscraper/scraper.py
+++ b/src/prowjobsscraper/scraper.py
@@ -37,7 +37,10 @@ class Scraper:
     def _is_assisted_job(j: prowjob.ProwJob) -> bool:
         if j.status.state not in ("success", "failure"):
             return False
-        elif not re.search("e2e-.*-assisted", j.spec.job):
+        elif not re.search("openshift.*assisted", j.spec.job):
+            return False
+        elif "openshift-release-fast-forward" in j.spec.job:
+            # exclude fast-forward jobs
             return False
         elif j.status.description and "Overridden" in j.status.description:
             # exclude overridden builds

--- a/tests/prowjobsscraper/scraper_assets/jobstep.json
+++ b/tests/prowjobsscraper/scraper_assets/jobstep.json
@@ -1,7 +1,7 @@
 {
     "job": {
       "spec": {
-        "job": "e2e-bla-assisted",
+        "job": "pull-ci-openshift-assisted-service-master-edge-subsystem-kubeapi-aws",
         "type": "postsubmit"
       },
       "status": {

--- a/tests/prowjobsscraper/test_scraper.py
+++ b/tests/prowjobsscraper/test_scraper.py
@@ -7,7 +7,48 @@ from pytest_httpserver import HTTPServer
 from prowjobsscraper import prowjob, scraper, step
 
 
-def test_non_assisted_jobs_are_filtered_out():
+@pytest.mark.parametrize(
+    "job_name, job_state,job_description,is_valid_job",
+    [
+        (  # <something>-openshift-assisted-<something> must be taken
+            "pull-ci-openshift-assisted-service-master-edge-subsystem-kubeapi-aws",
+            "success",
+            "",
+            True,
+        ),
+        (  # failures must be taken
+            "pull-ci-openshift-assisted-service-master-edge-subsystem-kubeapi-aws",
+            "failure",
+            "",
+            True,
+        ),
+        (  # pending jobs must be skipped
+            "pull-ci-openshift-assisted-service-master-edge-subsystem-kubeapi-aws",
+            "pending",
+            "",
+            False,
+        ),
+        (  # overridden jobs must be skipped
+            "pull-ci-openshift-assisted-service-master-edge-subsystem-kubeapi-aws",
+            "success",
+            "Overridden by Batman",
+            False,
+        ),
+        (  # openshift-<something>-assisted must be taken
+            "openshift-origin-27159-nightly-4.11-e2e-metal-assisted",
+            "success",
+            "",
+            True,
+        ),
+        (  # fast-forward jobs must be skipped
+            "periodic-openshift-release-fast-forward-assisted-service",
+            "success",
+            "",
+            False,
+        ),
+    ],
+)
+def test_job_filtering(job_name, job_state, job_description, is_valid_job):
     jobs = prowjob.ProwJobs.create_from_string(
         pkg_resources.resource_string(__name__, f"scraper_assets/prowjob.json")
     )
@@ -20,48 +61,15 @@ def test_non_assisted_jobs_are_filtered_out():
 
     scrape = scraper.Scraper(event_store, step_extractor)
 
-    jobs.items[0].spec.job = "we-don-t-say-the-name"
-    jobs.items[0].status.state = "success"
-    scrape.execute(jobs.copy(deep=True))
-    event_store.index_prow_jobs.assert_called_once_with([])
+    jobs.items[0].spec.job = job_name
+    jobs.items[0].status.state = job_state
+    jobs.items[0].status.description = job_description
+    scrape.execute(jobs)
 
-    event_store.reset_mock()
-    jobs.items[0].spec.job = "e2e-blala-assisted"
-    jobs.items[0].status.state = "pending"
-    scrape.execute(jobs.copy(deep=True))
-    event_store.index_prow_jobs.assert_called_once_with([])
-
-    event_store.reset_mock()
-    jobs.items[0].spec.job = "e2e-blala-assisted"
-    jobs.items[0].status.state = "success"
-    jobs.items[0].status.description = "Overridden by Batman"
-    scrape.execute(jobs.copy(deep=True))
-    event_store.index_prow_jobs.assert_called_once_with([])
-
-
-def test_assisted_jobs_are_not_filtered_out():
-    jobs = prowjob.ProwJobs.create_from_string(
-        pkg_resources.resource_string(__name__, f"scraper_assets/prowjob.json")
-    )
-
-    event_store = MagicMock()
-    event_store.scan_build_ids.return_value = []
-
-    step_extractor = MagicMock()
-    step_extractor.parse_prow_jobs.return_value = []
-
-    scrape = scraper.Scraper(event_store, step_extractor)
-
-    jobs.items[0].spec.job = "e2e-blala-assisted"
-    jobs.items[0].status.state = "success"
-    scrape.execute(jobs.copy(deep=True))
-    event_store.index_prow_jobs.assert_called_once_with(jobs.items)
-
-    event_store.reset_mock()
-    jobs.items[0].spec.job = "something-e2e-blala-assisted-test"
-    jobs.items[0].status.state = "failure"
-    scrape.execute(jobs.copy(deep=True))
-    event_store.index_prow_jobs.assert_called_once_with(jobs.items)
+    if is_valid_job:
+        event_store.index_prow_jobs.assert_called_once_with(jobs.items)
+    else:
+        event_store.index_prow_jobs.assert_called_once_with([])
 
 
 def test_existing_jobs_in_event_store_are_filtered_out():


### PR DESCRIPTION
Adapt the regex on the the job name to catch more assisted jobs (like
subsystem jobs and ai-operator jobs).
