### PR TITLE
NO-ISSUE: Handle malformed time in junit

### DIFF
--- a/src/prowjobsscraper/step.py
+++ b/src/prowjobsscraper/step.py
@@ -34,8 +34,13 @@ class JobStep(BaseModel):
                 break
 
         duration = timedelta(0)
-        if case.time:
-            duration = timedelta(seconds=float(case.time))
+        try:
+            if case.time:
+                duration = timedelta(seconds=float(case.time))
+        except ValueError:
+            logger.warn(
+                "Cannot parse duration in junit because it is malformed, job: %s", job
+            )
         return cls(
             job=job,
             name=case.name,

--- a/tests/prowjobsscraper/step_assets/malformed_time_junit_operator.xml
+++ b/tests/prowjobsscraper/step_assets/malformed_time_junit_operator.xml
@@ -1,0 +1,5 @@
+<testsuites>
+    <testsuite name="step graph" tests="50" skipped="0" failures="2" time="4550.287162788">
+        <testcase name="step1" time="0.2264XXXXX"/>
+    </testsuite>
+</testsuites>

--- a/tests/prowjobsscraper/test_step.py
+++ b/tests/prowjobsscraper/test_step.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pkg_resources
@@ -58,3 +59,30 @@ def test_step_extractor_with_valid_junit_should_return_steps():
             )
         )
         assert s.json(exclude_unset=True) == json.dumps(expected)
+
+
+def test_step_extractor_with_malformed_junit_should_return_steps():
+    jobs = ProwJobs.create_from_string(
+        pkg_resources.resource_string(__name__, f"step_assets/prowjobs.json")
+    )
+    junit = pkg_resources.resource_string(
+        __name__, f"step_assets/malformed_time_junit_operator.xml"
+    )
+
+    storage_client = MagicMock()
+    bucket = MagicMock()
+    blob = MagicMock()
+    storage_client.bucket.return_value = bucket
+    bucket.blob.return_value = blob
+    blob.download_as_string.return_value = junit
+
+    step_extractor = step.StepExtractor(storage_client)
+    steps = step_extractor.parse_prow_jobs(jobs)
+
+    storage_client.bucket.assert_called_once_with("origin-ci-test")
+    bucket.blob.assert_called_once_with(
+        "pr-logs/pull/openshift_assisted-service/4121/pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted/1549300279667593216/artifacts/junit_operator.xml"
+    )
+    assert len(steps) == 1
+    assert steps[0].duration == timedelta(0)
+    assert steps[0].name == "step1"


### PR DESCRIPTION
It looks like the time reported by the junit operator in Prow may be
malformed. As a consequence, prow-job-scraper stops its processing and
nothing is pushed to ES.

This change ignores the error and reports a duration of 0s when the
time is malformed.
