### PR TITLE
NO-ISSUE: upgrade google storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,23 @@ PROW_JOBS_SCRAPER_TAG := $(or $(PROW_JOBS_SCRAPER_TAG),latest)
 
 install:
 	pip install .
+	$(MAKE) clean-install
 
 install-lint:
 	pip install .[lint]
+	$(MAKE) clean-install
 
 install-unit-tests:
 	pip install .[test-runner]
+	$(MAKE) clean-install
 
 full-install: install install-lint install-unit-tests
+
+# setuptools leaves a build/ directory behind after "pip install"
+# clean it up in order to be able to install packages during
+# "build" and "test" phases in Prow
+clean-install:
+	rm -rf ./build
 
 unit-tests:
 	tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=45",
-    "setuptools_scm[toml]>=6.2",
+    "setuptools==65.5.1",
+    "setuptools_scm[toml]==7.0.5",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = { file = "LICENSE" }
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "requests==2.28.1",
-    "google-cloud-storage==2.5.0",
+    "google-cloud-storage==2.6.0",
     "junitparser==2.8.0",
     "pydantic==1.10.2",
     "opensearch-py==2.0.0",


### PR DESCRIPTION
- Bump google-cloud-storage from 2.5.0 to 2.6.0
- Cleanup temporary build directory that prevents the tests to run in Prow
