### PR TITLE
NO-ISSUE: fix permission issue with docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/python-39:latest
 
-COPY . .
+COPY --chown=1001:0 . .
 
-RUN make install
+RUN pip install --upgrade pip && make install
 
 ENTRYPOINT [ "prow-jobs-scraper" ]


### PR DESCRIPTION
The docker image fails to build because the perssions are not set
properly when copying the sources inside the image.

I take also the opportunity of this change to upgrade pip before
installing the application.
