### PR TITLE
MGMT-12553: Adjusting the index_name for queries

### DIFF
--- a/src/jobsautoreport/main.py
+++ b/src/jobsautoreport/main.py
@@ -16,7 +16,7 @@ def main() -> None:
 
     client = OpenSearch(os_host, http_auth=(os_usr, os_pwd))
 
-    index_name = config.ES_JOB_INDEX
+    index_name = config.ES_JOB_INDEX + "-*"
 
     now = datetime.now()
     a_week_ago = now - timedelta(weeks=1)


### PR DESCRIPTION
Adding a "-*" suffix in order that all jobs indexes will be considered while querying data from elasticsearch