### PR TITLE
MGMT-12553: Switching querying method from 'search' to 'scan'

### DIFF
--- a/src/jobsautoreport/query.py
+++ b/src/jobsautoreport/query.py
@@ -1,7 +1,8 @@
 import logging
 from datetime import datetime
+from typing import Any
 
-from opensearchpy import OpenSearch
+from opensearchpy import OpenSearch, helpers
 
 from jobsautoreport import utils
 from prowjobsscraper.event import JobDetails
@@ -99,6 +100,13 @@ class Querier:
 
     def _query_and_log(self, query: dict) -> list[JobDetails]:
         logger.info("OpenSearch query: %s", query)
-        res = self._os_client.search(body=query, index=self._index)
-        logger.info("OpenSearch response: %s", res)
-        return utils.parse_jobs(res)
+        jobs = self._scan(query)
+        return utils.parse_jobs(jobs)
+
+    def _scan(self, query: dict[str, Any]) -> list[dict[Any, Any]]:
+        res = helpers.scan(
+            client=self._os_client,
+            query=query,
+            index=self._index,
+        )
+        return list(res)

--- a/src/jobsautoreport/utils.py
+++ b/src/jobsautoreport/utils.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 from prowjobsscraper.event import JobDetails
 
 
-def parse_jobs(data: dict) -> list[JobDetails]:
-    jobs_list = [parse_job(job["_source"]["job"]) for job in data["hits"]["hits"]]
+def parse_jobs(data: list[dict[Any, Any]]) -> list[JobDetails]:
+    jobs_list = [parse_job(job["_source"]["job"]) for job in data]
     return jobs_list
 
 


### PR DESCRIPTION
Searching `jobs` yields only the first 10 results (by default) .
We want to switch from `search` to `scan` which utilizes scrolling, because this way we can:
1. Get all of the documents.
2. Limit the memory usage, because we only generate the next page at each time