### PR TITLE
MGMT-12553: fixing some typos, changing the cronjob schedule back to 'weekly', formatting the average job duration to be composed of minutes, seconds

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -132,7 +132,7 @@ parameters:
 - name: JOBS_AUTO_REPORT_SUSPEND
   value: "false"
 - name: JOBS_AUTO_REPORT_SCHEDULE
-  value: "*/30 * * * *"
+  value: "@weekly"
 - name: JOBS_AUTO_REPORT_WEBHOOK_SECRET_KEY
   value: webhook_url
 - name: JOBS_AUTO_REPORT_WEBHOOK_SECRET_NAME

--- a/src/jobsautoreport/main.py
+++ b/src/jobsautoreport/main.py
@@ -25,11 +25,14 @@ def main() -> None:
     a_week_ago = now - timedelta(weeks=1)
 
     querier = Querier(client, index_name)
-    processor = Reporter(querier)
+    reporter = Reporter(querier)
 
-    success_rate = processor.get_success_rate(a_week_ago, now)
-    number_of_jobs_triggered = processor.get_number_of_jobs_triggered(a_week_ago, now)
-    average_job_duration = processor.get_average_duration_of_jobs(a_week_ago, now)
+    success_rate = reporter.get_success_rate(a_week_ago, now)
+    number_of_jobs_triggered = reporter.get_number_of_jobs_triggered(a_week_ago, now)
+    average_jobs_duration = reporter.get_average_duration_of_jobs(a_week_ago, now)
+
+    if average_jobs_duration is None:
+        return
 
     slack_webhook_url = config.SLACK_WEBHOOK_URL
     webhook = WebhookClient(slack_webhook_url)
@@ -43,7 +46,11 @@ def main() -> None:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"• Jobs success rate: _{success_rate}_\n• Number of jobs triggered: _{number_of_jobs_triggered}_\n• Jobs average duration: _{average_job_duration}_",
+                    "text": f"""
+• Jobs success rate: _{success_rate}_
+• Number of jobs triggered: _{number_of_jobs_triggered}_
+• Jobs average duration: _{int(average_jobs_duration.total_seconds()) // 60}_ minutes, and _{int(average_jobs_duration.total_seconds())  % 60}_ seconds
+""",
                 },
             },
         ]

--- a/src/jobsautoreport/query.py
+++ b/src/jobsautoreport/query.py
@@ -35,7 +35,7 @@ class Querier:
         }
 
     @staticmethod
-    def _get_query_successfull_jobs(from_date: datetime, to_date: datetime) -> dict:
+    def _get_query_successful_jobs(from_date: datetime, to_date: datetime) -> dict:
         return {
             "query": {
                 "bool": {
@@ -55,7 +55,7 @@ class Querier:
         }
 
     @staticmethod
-    def _get_query_unsuccessfull_jobs(from_date: datetime, to_date: datetime) -> dict:
+    def _get_query_unsuccessful_jobs(from_date: datetime, to_date: datetime) -> dict:
         return {
             "query": {
                 "bool": {
@@ -74,16 +74,16 @@ class Querier:
             }
         }
 
-    def query_successfull_jobs(
+    def query_successful_jobs(
         self, from_date: datetime, to_date: datetime
     ) -> list[JobDetails]:
-        query = self._get_query_successfull_jobs(from_date, to_date)
+        query = self._get_query_successful_jobs(from_date, to_date)
         return self._query_and_log(query)
 
-    def query_unsuccessfull_jobs(
+    def query_unsuccessful_jobs(
         self, from_date: datetime, to_date: datetime
     ) -> list[JobDetails]:
-        query = self._get_query_unsuccessfull_jobs(from_date, to_date)
+        query = self._get_query_unsuccessful_jobs(from_date, to_date)
         return self._query_and_log(query)
 
     def query_number_of_jobs_triggered(

--- a/src/jobsautoreport/report.py
+++ b/src/jobsautoreport/report.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import Optional
 
 from jobsautoreport.query import Querier
 
@@ -8,13 +9,11 @@ class Reporter:
         self._querier = querier
 
     def get_success_rate(self, from_date: datetime, to_date: datetime) -> str:
-        successfull_jobs_list = self._querier.query_successfull_jobs(from_date, to_date)
-        unsuccessfull_jobs_list = self._querier.query_successfull_jobs(
-            from_date, to_date
-        )
-        if len(successfull_jobs_list) == 0:
+        successful_jobs_list = self._querier.query_successful_jobs(from_date, to_date)
+        unsuccessful_jobs_list = self._querier.query_successful_jobs(from_date, to_date)
+        if len(successful_jobs_list) == 0:
             return "0"
-        return f"{(len(successfull_jobs_list) / (len(unsuccessfull_jobs_list) + len(successfull_jobs_list))) * 100}%"
+        return f"{(len(successful_jobs_list) / (len(unsuccessful_jobs_list) + len(successful_jobs_list))) * 100}%"
 
     def get_number_of_jobs_triggered(
         self, from_date: datetime, to_date: datetime
@@ -24,9 +23,9 @@ class Reporter:
 
     def get_average_duration_of_jobs(
         self, from_date: datetime, to_date: datetime
-    ) -> float:
+    ) -> Optional[timedelta]:
         jobs_list = self._querier.query_number_of_jobs_triggered(from_date, to_date)
         if len(jobs_list) == 0:
-            return 0
-        avg = sum([job.duration for job in jobs_list]) / len(jobs_list)
-        return avg
+            return None
+        avg = int(sum([job.duration for job in jobs_list]) / len(jobs_list))
+        return timedelta(seconds=avg)


### PR DESCRIPTION
1. fixing typos.
2. changing the `cronjob` schedule back to `@weekly`
3. formatting job average duration to be composed of minutes and seconds