### PR TITLE
MGMT-12553: Fixing the indentation of lines written to slack

### DIFF
--- a/src/jobsautoreport/main.py
+++ b/src/jobsautoreport/main.py
@@ -46,11 +46,11 @@ def main() -> None:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"""
-• Jobs success rate: _{success_rate}_
-• Number of jobs triggered: _{number_of_jobs_triggered}_
-• Jobs average duration: _{int(average_jobs_duration.total_seconds()) // 60}_ minutes, and _{int(average_jobs_duration.total_seconds())  % 60}_ seconds
-""",
+                    "text": (
+                        f"• Jobs success rate: _{success_rate}_\n"
+                        f"• Number of jobs triggered: _{number_of_jobs_triggered}_\n"
+                        f"• Jobs average duration: _{int(average_jobs_duration.total_seconds()) // 60}_ minutes, and _{int(average_jobs_duration.total_seconds())  % 60}_ seconds"
+                    ),
                 },
             },
         ]


### PR DESCRIPTION
At the moment details of the Jobs written to slack is structured as a multi-line string, which forces specific code indentation which does not look good.

Solution: splitting the multi-line string to separated strings. 