### PR TITLE
MGMT-12706: Extracting the slack logic from main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# junit
+junit-*

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -103,11 +103,17 @@ objects:
                   secretKeyRef:
                     key: master_user_password
                     name: elastic-master-credentials
-              - name: SLACK_WEBHOOK_URL
+              - name: SLACK_BOT_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    key: ${JOBS_AUTO_REPORT_WEBHOOK_SECRET_KEY}
-                    name: ${JOBS_AUTO_REPORT_WEBHOOK_SECRET_NAME}
+                    key: ${JOBS_AUTO_REPORT_SLACK_BOT_TOKEN_KEY}
+                    name: ${JOBS_AUTO_REPORT_SLACK_BOT_TOKEN_NAME}
+              - name: SLACK_CHANNEL_ID
+                valueFrom:
+                  secretKeyRef:
+                    key: ${JOBS_AUTO_REPORT_SLACK_CHANNEL_ID_KEY}
+                    name: ${JOBS_AUTO_REPORT_SLACK_CHANNEL_ID_NAME}
+
 parameters:
 - name: IMAGE_NAME
   value: "quay.io/app-sre/prow-jobs-scraper"
@@ -133,7 +139,11 @@ parameters:
   value: "false"
 - name: JOBS_AUTO_REPORT_SCHEDULE
   value: "@weekly"
-- name: JOBS_AUTO_REPORT_WEBHOOK_SECRET_KEY
-  value: webhook_url
-- name: JOBS_AUTO_REPORT_WEBHOOK_SECRET_NAME
-  value: jobs-auto-report-slack-webhook
+- name: JOBS_AUTO_REPORT_SLACK_BOT_TOKEN_NAME
+  value: jobs-auto-report-slack-bot-token
+- name: JOBS_AUTO_REPORT_SLACK_BOT_TOKEN_KEY
+  value: slack-bot-token
+- name: JOBS_AUTO_REPORT_SLACK_CHANNEL_ID_NAME
+  value: jobs-auto-report-slack-channel-id
+- name: JOBS_AUTO_REPORT_SLACK_CHANNEL_ID_KEY
+  value: slack-channel-id

--- a/src/jobsautoreport/config.py
+++ b/src/jobsautoreport/config.py
@@ -4,5 +4,6 @@ ES_URL = os.environ["ES_URL"]
 ES_USER = os.environ["ES_USER"]
 ES_PASSWORD = os.environ["ES_PASSWORD"]
 ES_JOB_INDEX = os.environ["ES_JOB_INDEX"]
-SLACK_WEBHOOK_URL = os.environ["SLACK_WEBHOOK_URL"]
+SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
+SLACK_CHANNEL_ID = os.environ["SLACK_CHANNEL_ID"]
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")

--- a/src/jobsautoreport/slack.py
+++ b/src/jobsautoreport/slack.py
@@ -1,0 +1,125 @@
+import logging
+from typing import Any
+
+from slack_sdk import WebClient
+
+logger = logging.getLogger(__name__)
+
+
+class SlackReporter:
+    def __init__(self, web_client: WebClient, channel_id: str) -> None:
+        self._client = web_client
+        self._channel_id = channel_id
+
+    def send_report(self, data: dict[str, Any]) -> None:
+        if not self._is_valid(data):
+            return
+
+        blocks_list = self._format_as_message(data)
+        res = self._client.chat_postMessage(
+            channel=self._channel_id, blocks=blocks_list
+        )
+        time_stamp = res["ts"]
+
+    def comment_on_message(
+        self, msg_time_stamp: str, data: list[dict[str, Any]]
+    ) -> None:
+        blocks_list = self._format_as_comment(data)
+        res = self._client.chat_postMessage(
+            channel=self._channel_id, blocks=blocks_list, ts=msg_time_stamp
+        )
+
+    @staticmethod
+    def _format_as_message(data: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Jobs Weekly Report",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Jobs success rate*: {data['success_rate']}",
+                    }
+                ],
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Number of jobs triggered*: {data['number_of_jobs_triggered']}",
+                    }
+                ],
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Average duration*:{data['average_jobs_duration']}",
+                    }
+                ],
+            },
+        ]
+
+    @staticmethod
+    def _format_as_comment(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Top 10 failing e2e periodic jobs",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"1. Job name: {data[0]['name']}"},
+                    {"type": "mrkdwn", "text": f"Job score: {data[0]['score']}"},
+                ],
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"2. Job name: {data[1]['name']}"},
+                    {"type": "mrkdwn", "text": f"Job score: {data[1]['score']}"},
+                ],
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"3. Job name: {data[2]['name']}"},
+                    {"type": "mrkdwn", "text": f"Job score: {data[2]['score']}"},
+                ],
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"4. Job name: {data[3]['name']}"},
+                    {"type": "mrkdwn", "text": f"Job score: {data[3]['score']}"},
+                ],
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"5. Job name: {data[4]['name']}"},
+                    {"type": "mrkdwn", "text": f"Job score: {data[4]['score']}"},
+                ],
+            },
+        ]
+
+    @staticmethod
+    def _is_valid(data: dict[str, Any]) -> bool:
+        for v in data.values():
+            if v is None:
+                return False
+        return True

--- a/tests/jobsautoreport/test_slack.py
+++ b/tests/jobsautoreport/test_slack.py
@@ -1,0 +1,58 @@
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from jobsautoreport.slack import SlackReporter
+
+
+def test_send_report_should_successfully_call_slack_api_with_expected_message_format():
+    test_data = {
+        "success_rate": "test-success-rate",
+        "number_of_jobs_triggered": 30,
+        "average_jobs_duration": timedelta(minutes=30),
+    }
+    test_channel = "abcdefgh"
+    expected_blocks = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Jobs Weekly Report",
+                "emoji": True,
+            },
+        },
+        {
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Jobs success rate*: {test_data['success_rate']}",
+                }
+            ],
+        },
+        {
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Number of jobs triggered*: {test_data['number_of_jobs_triggered']}",
+                }
+            ],
+        },
+        {
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Average duration*:{test_data['average_jobs_duration']}",
+                }
+            ],
+        },
+    ]
+
+    web_client_mock = MagicMock()
+    web_client_mock.chat_postMessage = MagicMock()
+    slack_reporter = SlackReporter(web_client=web_client_mock, channel_id=test_channel)
+    slack_reporter.send_report(test_data)
+    web_client_mock.chat_postMessage.assert_called_once_with(
+        channel=test_channel, blocks=expected_blocks
+    )


### PR DESCRIPTION
Currently the logic for sending messages in `slack`  is based in main module. s part of the app's reconstructing effort, we want to extract the logic to its own class. In addition we switch from `WebhookClient` to `WebClient` a class with capability of commenting on messages in `slack` 