### PR TITLE
NO-ISSUE: Fixed sorting wrong way

### DIFF
--- a/tests/jobsautoreport/test_report.py
+++ b/tests/jobsautoreport/test_report.py
@@ -221,7 +221,7 @@ expected_report = Report(
     top_10_failing_e2e_or_subsystem_periodic_jobs=[
         (
             "pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-0",
-            JobStatesCount(successes=2, failures=1, success_rate=66.67),
+            JobStatesCount(successes=2, failures=1, failure_rate=33.33),
         )
     ],
     number_of_e2e_or_subsystem_presubmit_jobs=4,
@@ -232,11 +232,11 @@ expected_report = Report(
     top_10_failing_e2e_or_subsystem_presubmit_jobs=[
         (
             "pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-2",
-            JobStatesCount(successes=2, failures=0, success_rate=100.0),
+            JobStatesCount(successes=2, failures=0, failure_rate=0),
         ),
         (
             "pull-ci-openshift-assisted-service-master-edge-subsystem-metal-assisted-3",
-            JobStatesCount(successes=1, failures=1, success_rate=50.0),
+            JobStatesCount(successes=1, failures=1, failure_rate=50.0),
         ),
     ],
     top_5_most_triggered_e2e_or_subsystem_jobs=[

--- a/tests/jobsautoreport/test_slack.py
+++ b/tests/jobsautoreport/test_slack.py
@@ -11,7 +11,7 @@ def test_send_report_should_successfully_call_slack_api_with_expected_message_fo
         number_of_failing_e2e_or_subsystem_periodic_jobs=3,
         success_rate_for_e2e_or_subsystem_periodic_jobs=75,
         top_10_failing_e2e_or_subsystem_periodic_jobs=[
-            ("fake-job-1", JobStatesCount(successes=3, failures=1, success_rate=75))
+            ("fake-job-1", JobStatesCount(successes=3, failures=1, failure_rate=25))
         ],
         number_of_e2e_or_subsystem_presubmit_jobs=24,
         number_of_successful_e2e_or_subsystem_presubmit_jobs=8,
@@ -19,7 +19,7 @@ def test_send_report_should_successfully_call_slack_api_with_expected_message_fo
         number_of_rehearsal_jobs=0,
         success_rate_for_e2e_or_subsystem_presubmit_jobs=33.33,
         top_10_failing_e2e_or_subsystem_presubmit_jobs=[
-            ("fake-job-2", JobStatesCount(successes=1, failures=2, success_rate=33.33))
+            ("fake-job-2", JobStatesCount(successes=1, failures=2, failure_rate=66.67))
         ],
         top_5_most_triggered_e2e_or_subsystem_jobs=[
             ("fake-job-2", 24),


### PR DESCRIPTION
`Plotly` presents the records from bottom to top (first element in the list is bottom). In order to present the worse results at the top, I Changed the sorting direction so it will show the worst at the top instead of the bottom, although it is not correct for over than 10 jobs, as it takes the min(10, number_of_jobs) best results, which are not also the 10 worse results in this case. Hence, I changed the sorting to the right direction and just reversed the presentation of them.