### PR TITLE
NO-ISSUE: Use iso calendar to name ES indices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ test-runner = [
     "tox==4.2.4",
 ]
 unit-tests = [
+    "freezegun==1.2.1",
     "pytest==7.2.0",
     "pytest-cov==4.0.0",
     "pytest-httpserver==1.0.6",


### PR DESCRIPTION
On 01/01/2023, a new index was created because the implementation of
python consisders this day to be the week 0 in year 2023.

We rely on the build_ids inserted in the last 2 indices to make sure we
don't insert the same job twice into ES. Because of this 'ephemeral'
week on day 01/01/2023, we skiped the previous index that was created
(week 52, year 2022) to retrieve the existing build_ids. It led to
insert duplicated jobs.

This change fixes this issue by using the ISO calendar which returns
always the same week consistantly independantly from the current year:

With strftime:
```
>>> date(2023, 1, 1).strftime("%Y.%W")
'2023.00'
>>> date(2022, 12, 30).strftime("%Y.%W")
'2022.52'
```

with isocalendar:
```
>>> date(2023, 1, 1).isocalendar()
datetime.IsoCalendarDate(year=2022, week=52, weekday=7)
>>> date(2022, 12, 30).isocalendar()
datetime.IsoCalendarDate(year=2022, week=52, weekday=5)
```
