### PR TITLE
NO-ISSUE: Changing the report time, making message clearer

### DIFF
--- a/src/jobsautoreport/main.py
+++ b/src/jobsautoreport/main.py
@@ -20,14 +20,16 @@ def main() -> None:
 
     client = OpenSearch(os_host, http_auth=(os_usr, os_pwd))
 
-    now = datetime.now(tz=timezone.utc)
+    # Job execution takes 1-2 hours, and is timed out after 5. We want to have at least 6 hours for all the jobs in the report's interval to be indexed in elasticsearch
+    six_hours_ago = datetime.now(tz=timezone.utc) - timedelta(hours=6)
     report_end_time = datetime(
-        year=now.year,
-        month=now.month,
-        day=now.day,
-        hour=8,
+        year=six_hours_ago.year,
+        month=six_hours_ago.month,
+        day=six_hours_ago.day,
+        hour=six_hours_ago.hour,
         minute=0,
         second=0,
+        microsecond=0,
         tzinfo=timezone.utc,
     )
     report_start_time = report_end_time - timedelta(weeks=1)

--- a/src/jobsautoreport/slack.py
+++ b/src/jobsautoreport/slack.py
@@ -118,14 +118,12 @@ class SlackReporter:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"•\t _{report.number_of_e2e_or_subsystem_periodic_jobs}_ jobs - :slack-green: {report.number_of_successful_e2e_or_subsystem_periodic_jobs} :x: {report.number_of_failing_e2e_or_subsystem_periodic_jobs}",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"•\t _{report.success_rate_for_e2e_or_subsystem_periodic_jobs}%_ succeeded",
+                    "text": (
+                        f"•\t _{report.number_of_e2e_or_subsystem_periodic_jobs}_ in total\n"
+                        f" \t\t *-* :done-circle-check: {report.number_of_successful_e2e_or_subsystem_periodic_jobs} succeeded\n"
+                        f" \t\t *-* :x: {report.number_of_failing_e2e_or_subsystem_periodic_jobs} failed\n"
+                        f" \t  _{report.success_rate_for_e2e_or_subsystem_periodic_jobs}%_ *success rate*\n"
+                    ),
                 },
             },
         ]
@@ -145,7 +143,12 @@ class SlackReporter:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"•\t _{report.number_of_e2e_or_subsystem_presubmit_jobs}_ jobs - :slack-green: {report.number_of_successful_e2e_or_subsystem_presubmit_jobs} :x: {report.number_of_failing_e2e_or_subsystem_presubmit_jobs}",
+                    "text": (
+                        f"•\t _{report.number_of_e2e_or_subsystem_presubmit_jobs}_ in total\n"
+                        f" \t\t *-* :done-circle-check: {report.number_of_successful_e2e_or_subsystem_presubmit_jobs} succeeded\n"
+                        f" \t\t *-* :x: {report.number_of_failing_e2e_or_subsystem_presubmit_jobs} failed\n"
+                        f" \t  _{report.success_rate_for_e2e_or_subsystem_presubmit_jobs}%_ *success rate*\n"
+                    ),
                 },
             },
             {
@@ -153,13 +156,6 @@ class SlackReporter:
                 "text": {
                     "type": "mrkdwn",
                     "text": f"•\t _{report.number_of_rehearsal_jobs}_ rehearsal jobs triggered",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"•\t _{report.success_rate_for_e2e_or_subsystem_presubmit_jobs}%_ succeeded",
                 },
             },
         ]
@@ -179,7 +175,11 @@ class SlackReporter:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"_{report.total_number_of_machine_leased}_ machines leased - :slack-green: {report.number_of_successful_machine_leases} :x: {report.number_of_unsuccessful_machine_leases}",
+                    "text": (
+                        f"•\t _{report.total_number_of_machine_leased}_ machine lease attempts\n"
+                        f" \t\t *-* :done-circle-check: {report.number_of_successful_machine_leases} succeeded\n"
+                        f" \t\t *-* :x: {report.number_of_unsuccessful_machine_leases} failed\n"
+                    ),
                 },
             },
         ]

--- a/tests/jobsautoreport/test_slack.py
+++ b/tests/jobsautoreport/test_slack.py
@@ -45,14 +45,12 @@ def test_send_report_should_successfully_call_slack_api_with_expected_message_fo
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"•\t _{report.number_of_e2e_or_subsystem_periodic_jobs}_ jobs - :slack-green: {report.number_of_successful_e2e_or_subsystem_periodic_jobs} :x: {report.number_of_failing_e2e_or_subsystem_periodic_jobs}",
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"•\t _{report.success_rate_for_e2e_or_subsystem_periodic_jobs}%_ succeeded",
+                "text": (
+                    f"•\t _{report.number_of_e2e_or_subsystem_periodic_jobs}_ in total\n"
+                    f" \t\t *-* :done-circle-check: {report.number_of_successful_e2e_or_subsystem_periodic_jobs} succeeded\n"
+                    f" \t\t *-* :x: {report.number_of_failing_e2e_or_subsystem_periodic_jobs} failed\n"
+                    f" \t  _{report.success_rate_for_e2e_or_subsystem_periodic_jobs}%_ *success rate*\n"
+                ),
             },
         },
     ]
@@ -70,7 +68,12 @@ def test_send_report_should_successfully_call_slack_api_with_expected_message_fo
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"•\t _{report.number_of_e2e_or_subsystem_presubmit_jobs}_ jobs - :slack-green: {report.number_of_successful_e2e_or_subsystem_presubmit_jobs} :x: {report.number_of_failing_e2e_or_subsystem_presubmit_jobs}",
+                "text": (
+                    f"•\t _{report.number_of_e2e_or_subsystem_presubmit_jobs}_ in total\n"
+                    f" \t\t *-* :done-circle-check: {report.number_of_successful_e2e_or_subsystem_presubmit_jobs} succeeded\n"
+                    f" \t\t *-* :x: {report.number_of_failing_e2e_or_subsystem_presubmit_jobs} failed\n"
+                    f" \t  _{report.success_rate_for_e2e_or_subsystem_presubmit_jobs}%_ *success rate*\n"
+                ),
             },
         },
         {
@@ -78,13 +81,6 @@ def test_send_report_should_successfully_call_slack_api_with_expected_message_fo
             "text": {
                 "type": "mrkdwn",
                 "text": f"•\t _{report.number_of_rehearsal_jobs}_ rehearsal jobs triggered",
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"•\t _{report.success_rate_for_e2e_or_subsystem_presubmit_jobs}%_ succeeded",
             },
         },
     ]
@@ -102,7 +98,11 @@ def test_send_report_should_successfully_call_slack_api_with_expected_message_fo
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"_{report.total_number_of_machine_leased}_ machines leased - :slack-green: {report.number_of_successful_machine_leases} :x: {report.number_of_unsuccessful_machine_leases}",
+                "text": (
+                    f"•\t _{report.total_number_of_machine_leased}_ machine lease attempts\n"
+                    f" \t\t *-* :done-circle-check: {report.number_of_successful_machine_leases} succeeded\n"
+                    f" \t\t *-* :x: {report.number_of_unsuccessful_machine_leases} failed\n"
+                ),
             },
         },
     ]


### PR DESCRIPTION
1. Changing the report time to - start_time: execution_time - 6 hours - week, end_time: execution_time - 6 hours, this way more jobs are supposed to be finished and indexed in elastic search before execution time.
2. Making the slack message clearer.
