### PR TITLE
NO-ISSUE: Fix access path to job build_id

### DIFF
--- a/src/prowjobsscraper/equinix_usages.py
+++ b/src/prowjobsscraper/equinix_usages.py
@@ -75,8 +75,6 @@ class EquinixUsagesExtractor:
     def get_project_usages(
         self,
     ) -> list[EquinixUsage]:
-        print(self._start_time.strftime(self._USAGES_TIME_FORMAT))
-        print(self._end_time.strftime(self._USAGES_TIME_FORMAT))
         equinix_project_usages = requests.get(
             url=self._EQUINIX_METAL_ENDPOINT.format(
                 self._project_id,

--- a/src/prowjobsscraper/event.py
+++ b/src/prowjobsscraper/event.py
@@ -147,11 +147,11 @@ class EventStoreElastic:
         )
         self._usages_index.index(equinix_usages)
 
-    def scan_build_ids_from_index(self, index_prefix_singular: str) -> set[str]:
-        results = self.__dict__[f"_{index_prefix_singular}s_index"].scan(
-            {"_source": [f"{index_prefix_singular}.build_id"]}
+    def scan_build_ids_from_index(self, index_prefix: str) -> set[str]:
+        results = self.__dict__[f"_{index_prefix}_index"].scan(
+            {"_source": ["job.build_id"]}
         )
-        return {r["_source"][f"{index_prefix_singular}"]["build_id"] for r in results}
+        return {r["_source"]["job"]["build_id"] for r in results}
 
 
 class _EsIndex:

--- a/src/prowjobsscraper/scraper.py
+++ b/src/prowjobsscraper/scraper.py
@@ -26,7 +26,7 @@ class Scraper:
         jobs.items = [j for j in jobs.items if self._is_assisted_job(j)]
 
         # filter out jobs already stored
-        known_jobs_build_ids = self._event_store.scan_build_ids_from_index("job")
+        known_jobs_build_ids = self._event_store.scan_build_ids_from_index("jobs")
         jobs.items = [
             j for j in jobs.items if j.status.build_id not in known_jobs_build_ids
         ]
@@ -38,7 +38,7 @@ class Scraper:
         steps = self._step_extractor.parse_prow_jobs(jobs)
 
         # Retrieve equinix machines usages not already stored
-        known_usages_build_ids = self._event_store.scan_build_ids_from_index("usage")
+        known_usages_build_ids = self._event_store.scan_build_ids_from_index("usages")
         usages = [
             usage
             for usage in self._equinix_usages_extractor.get_project_usages()

--- a/tests/prowjobsscraper/test_event.py
+++ b/tests/prowjobsscraper/test_event.py
@@ -60,7 +60,7 @@ def test_scan_build_id_from_jobs_index_when_results_are_expected(scan):
         step_index_basename="steps",
         usage_index_basename="usages",
     )
-    build_ids = event_store.scan_build_ids_from_index("job")
+    build_ids = event_store.scan_build_ids_from_index("jobs")
 
     expected_search_indices = (
         f"jobs-{_EXPECTED_CURRENT_INDEX_SUFFIX},jobs-{_EXPECTED_PREVIOUS_INDEX_SUFFIX}"
@@ -76,9 +76,9 @@ def test_scan_build_id_from_jobs_index_when_results_are_expected(scan):
 def test_scan_build_id_from_usages_index_when_results_are_expected(scan):
     es_client = MagicMock()
     scan.return_value = [
-        {"_source": {"usage": {"build_id": 1}}},
-        {"_source": {"usage": {"build_id": 2}}},
-        {"_source": {"usage": {"build_id": 3}}},
+        {"_source": {"job": {"build_id": 1}}},
+        {"_source": {"job": {"build_id": 2}}},
+        {"_source": {"job": {"build_id": 3}}},
     ]
     event_store = event.EventStoreElastic(
         client=es_client,
@@ -86,12 +86,12 @@ def test_scan_build_id_from_usages_index_when_results_are_expected(scan):
         step_index_basename="steps",
         usage_index_basename="usages",
     )
-    build_ids = event_store.scan_build_ids_from_index("usage")
+    build_ids = event_store.scan_build_ids_from_index("usages")
 
     expected_search_indices = f"usages-{_EXPECTED_CURRENT_INDEX_SUFFIX},usages-{_EXPECTED_PREVIOUS_INDEX_SUFFIX}"
 
     scan.assert_called_once()
-    print(scan.call_args.kwargs["index"])
+
     assert scan.call_args.kwargs["index"] == expected_search_indices
     assert build_ids == {1, 2, 3}
 
@@ -106,7 +106,7 @@ def test_scan_build_id_from_jobs_index_when_no_results(scan):
         step_index_basename="steps",
         usage_index_basename="usages",
     )
-    build_ids = event_store.scan_build_ids_from_index("job")
+    build_ids = event_store.scan_build_ids_from_index("jobs")
 
     scan.assert_called_once()
     assert len(build_ids) == 0


### PR DESCRIPTION
As a followup to https://github.com/openshift-assisted/prow-jobs-scraper/pull/140, this PR is fixing the way we access retrieved usages. currently when scanning for job build ids for usages in `scan_build_ids_from_index`, we try to access it by `usage` keyword instead of `job`