### PR TITLE
MGMT-13001: Changing the way usage is identified from its corresponding job build's id to a tuple of name and plan

### DIFF
--- a/src/prowjobsscraper/equinix_usages.py
+++ b/src/prowjobsscraper/equinix_usages.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from enum import Enum
-from typing import Final, Optional
+from typing import Any, Final, Optional
 
 import requests
 from pydantic import BaseModel
@@ -14,6 +14,24 @@ class EquinixUsagesScrapeInterval(Enum):
     DAY = "day"
     WEEK = "week"
     MONTH = "month"
+
+
+class EquinixUsageIdentifier(BaseModel):
+    name: str
+    plan: str
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.plan))
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, self.__class__)
+            and self.name == other.name
+            and self.plan == self.plan
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
 
 
 class EquinixUsage(BaseModel):
@@ -35,6 +53,9 @@ class EquinixUsage(BaseModel):
     @property
     def job_build_id(self) -> str:
         return self.name.split("-")[-1]
+
+    def to_identifier(self) -> EquinixUsageIdentifier:
+        return EquinixUsageIdentifier(name=self.name, plan=self.plan)
 
 
 class EquinixUsageEvent(BaseModel):

--- a/src/prowjobsscraper/scraper.py
+++ b/src/prowjobsscraper/scraper.py
@@ -26,7 +26,7 @@ class Scraper:
         jobs.items = [j for j in jobs.items if self._is_assisted_job(j)]
 
         # filter out jobs already stored
-        known_jobs_build_ids = self._event_store.scan_build_ids_from_index("jobs")
+        known_jobs_build_ids = self._event_store.scan_build_ids()
         jobs.items = [
             j for j in jobs.items if j.status.build_id not in known_jobs_build_ids
         ]
@@ -38,11 +38,11 @@ class Scraper:
         steps = self._step_extractor.parse_prow_jobs(jobs)
 
         # Retrieve equinix machines usages not already stored
-        known_usages_build_ids = self._event_store.scan_build_ids_from_index("usages")
+        known_usages_identifiers = self._event_store.scan_usages_identifiers()
         usages = [
             usage
             for usage in self._equinix_usages_extractor.get_project_usages()
-            if usage.job_build_id not in known_usages_build_ids
+            if usage.to_identifier() not in known_usages_identifiers
         ]
 
         # Store jobs and steps into their respective indices

--- a/tests/prowjobsscraper/test_scraper.py
+++ b/tests/prowjobsscraper/test_scraper.py
@@ -54,7 +54,7 @@ def test_job_filtering(job_name, job_state, job_description, is_valid_job):
     )
 
     event_store = MagicMock()
-    event_store.scan_build_ids_from_index.return_value = []
+    event_store.scan_build_ids.return_value = []
 
     step_extractor = MagicMock()
     step_extractor.parse_prow_jobs.return_value = []
@@ -88,7 +88,7 @@ def test_existing_jobs_in_event_store_are_filtered_out():
     )
 
     event_store = MagicMock()
-    event_store.scan_build_ids_from_index.return_value = [jobs.items[0].status.build_id]
+    event_store.scan_build_ids.return_value = [jobs.items[0].status.build_id]
 
     step_extractor = MagicMock()
     step_extractor.parse_prow_jobs.return_value = []
@@ -158,7 +158,12 @@ def test_existing_usages_in_event_store_are_filtered_out():
     ]
 
     event_store = MagicMock()
-    event_store.scan_build_ids_from_index.return_value = {"1633695483341836288"}
+    event_store.scan_usages_identifiers.return_value = {
+        equinix_usages.EquinixUsageIdentifier(
+            name="ipi-ci-op-3i64pdkt-0f69d-1633695483341836288",
+            plan="Outbound Bandwidth",
+        )
+    }
 
     step_extractor = MagicMock()
     step_extractor.parse_prow_jobs.return_value = []


### PR DESCRIPTION
Currently `prow-jobs-scraper` scraps usages from `Equinix` metal API in a given interval, and indexes in `elastic` only those whose job's `build_id` is not already indexed. This doesn't work well because jobs can have multiple usages which currently allows only one of them to be indexed. Hence, we change the identifier of a usage to be a tuple of `(name, plan)`, which suppose to be unique. 