### PR TITLE
NO-ISSUE: Changing the bandwidth usages dates to match their non-bandwidth counterpart

### DIFF
--- a/src/prowjobsscraper/equinix_usages.py
+++ b/src/prowjobsscraper/equinix_usages.py
@@ -108,4 +108,68 @@ class EquinixUsagesExtractor:
             headers={self._EQUINIX_ENDPOINT_HEADER: self._project_token},
         ).json()["usages"]
         logger.info("%s usages retrieved successfully", len(equinix_project_usages))
-        return [EquinixUsage.parse_obj(usage) for usage in equinix_project_usages]
+        return self._process_usages(
+            [EquinixUsage.parse_obj(usage) for usage in equinix_project_usages]
+        )
+
+    def _is_usage_in_interval(self, usage: EquinixUsage) -> bool:
+        """Usage is considered to be within the time interval
+        if its complete duration falls within that interval
+        and it has reached completion.
+        """
+        return (
+            usage.end_date is not None
+            and usage.start_date >= self._start_time
+            and usage.end_date <= self._end_time
+        )
+
+    def _process_usages(cls, usages: list[EquinixUsage]) -> list[EquinixUsage]:
+        """We should index a usage if:
+        - It is a non-bandwidth usage and falls within
+          the designated time interval for data gathering.
+        - It is a bandwidth usage and its corresponding non-bandwidth usage
+          occurs within the time interval. In this situation,
+          we adjust the start date and end date of the bandwidth usage to match those of its non-bandwidth counterpart.
+          This ensures that they would be retrieved together in the report.
+        """
+        usages_should_be_indexed = []
+        for usage in usages:
+            if usage.is_bandwidth_usage():
+                cls._change_bandwidth_usage_time_interval(
+                    non_bandwidth_usage=cls._find_non_bandwidth_usage(
+                        usage_name=usage.name, usages=usages
+                    ),
+                    bandwidth_usage=usage,
+                )
+
+            if cls._is_usage_in_interval(usage=usage):
+                usages_should_be_indexed.append(usage)
+
+        return usages_should_be_indexed
+
+    @classmethod
+    def _change_bandwidth_usage_time_interval(
+        cls, non_bandwidth_usage: EquinixUsage, bandwidth_usage: EquinixUsage
+    ) -> EquinixUsage:
+        """Modifies the time of the bandwidth usage to match that of the non-bandwidth usage."""
+        bandwidth_usage.start_date = non_bandwidth_usage.start_date
+        bandwidth_usage.end_date = non_bandwidth_usage.end_date
+        return bandwidth_usage
+
+    @staticmethod
+    def _find_non_bandwidth_usage(
+        usage_name: str, usages: list[EquinixUsage]
+    ) -> EquinixUsage:
+        """Locates the non-bandwidth usage identified by the name usage_name.
+        A usage is classified as bandwidth usage if its plan includes the term "Bandwidth".
+        Presently, we recognize two types of bandwidth usages:
+          - Outbound Bandwidth
+          - Backend Transfer Bandwidth\n
+        If any such usage exists, there should be a corresponding
+        non-bandwidth usage associated with it.
+        """
+        return next(
+            usage
+            for usage in usages
+            if usage.name == usage_name and not usage.is_bandwidth_usage()
+        )

--- a/tests/prowjobsscraper/test_equinix_usages.py
+++ b/tests/prowjobsscraper/test_equinix_usages.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,21 @@ def test_get_project_usages(requests: MagicMock):
         "usages": [
             {
                 "description": None,
+                "facility": "da11",
+                "metro": "da",
+                "name": "ipi-ci-op-nnk50j82-5ed26-1634705984507088896",
+                "plan": "c3.medium.x86",
+                "plan_version": "c3.medium.x86 v2 (Dell EPYC 7402P)",
+                "price": 1.5,
+                "quantity": 2.0,
+                "total": 3.0,
+                "type": "Instance",
+                "unit": "hour",
+                "start_date": "2023-03-20T07:56:49Z",
+                "end_date": "2023-03-20T09:51:49Z",
+            },
+            {
+                "description": None,
                 "end_date": "2023-03-31T23:59:59Z",
                 "facility": "dc13",
                 "metro": "dc",
@@ -19,22 +35,8 @@ def test_get_project_usages(requests: MagicMock):
                 "price": 0.05,
                 "quantity": 2,
                 "start_date": "2023-03-01T00:00:00Z",
+                "end_date": "2023-03-30T00:00:00Z",
                 "total": 0.1,
-                "type": "Instance",
-                "unit": "GB",
-            },
-            {
-                "description": None,
-                "end_date": "2023-03-31T23:59:59Z",
-                "facility": "am6",
-                "metro": "am",
-                "name": "ipi-ci-op-tb33cyhd-20a45-1638140834400440320",
-                "plan": "Outbound Bandwidth",
-                "plan_version": "Outbound Bandwidth",
-                "price": 0.05,
-                "quantity": 4,
-                "start_date": "2023-03-01T00:00:00Z",
-                "total": 0.2,
                 "type": "Instance",
                 "unit": "GB",
             },
@@ -42,21 +44,70 @@ def test_get_project_usages(requests: MagicMock):
                 "description": None,
                 "facility": "dc13",
                 "metro": "dc",
-                "name": "ipi-ci-op-3i64pdkt-0f69d-1633695483341836288",
-                "plan": "Outbound Bandwidth",
-                "plan_version": "Outbound Bandwidth",
+                "name": "ipi-ci-op-nnk50j82-5ed26-1634705984507088896",
+                "plan": "Backend Transfer Bandwidth",
+                "plan_version": "Backend Transfer Bandwidth",
                 "price": 0.05,
                 "quantity": 3,
                 "start_date": "2023-03-01T00:00:00Z",
+                "end_date": "2023-03-30T00:00:00Z",
                 "total": 0.15,
                 "type": "Instance",
                 "unit": "GB",
+            },
+            {
+                "description": None,
+                "facility": "dc13",
+                "metro": "dc",
+                "name": "ipi-ci-op-qbtg69w9-88355-1648876148169379840",
+                "plan": "c3.small.x86",
+                "plan_version": "c3.small.x86 v1",
+                "price": 0.75,
+                "quantity": 1.0,
+                "total": 0.75,
+                "type": "Instance",
+                "unit": "hour",
+                "start_date": "2023-03-21T00:00:00Z",
+                "end_date": "2023-03-21T02:00:00Z",
+            },
+            {
+                "description": None,
+                "facility": "dc13",
+                "metro": "dc",
+                "name": "ipi-ci-op-qbtg69w9-88355-1234576148169312345",
+                "plan": "c3.small.x86",
+                "plan_version": "c3.small.x86 v1",
+                "price": 0.75,
+                "quantity": 1.0,
+                "total": 0.75,
+                "type": "Instance",
+                "unit": "hour",
+                "start_date": "2023-03-21T00:00:00Z",
             },
         ]
     }
 
     requests.get.return_value.json.return_value = response_usages
-    equinix = EquinixUsagesExtractor(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+    start_time = datetime(
+        year=2023, month=3, day=20, hour=5, minute=0, second=0, tzinfo=timezone.utc
+    )
+    end_time = datetime(
+        year=2023, month=3, day=20, hour=11, minute=0, second=0, tzinfo=timezone.utc
+    )
+    equinix = EquinixUsagesExtractor(MagicMock(), MagicMock(), start_time, end_time)
     usages = equinix.get_project_usages()
 
     assert len(usages) == 3
+    assert (
+        len(
+            [
+                usage
+                for usage in usages
+                if usage.start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+                == "2023-03-20T07:56:49Z"
+                and usage.end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+                == "2023-03-20T09:51:49Z"
+            ]
+        )
+        == 3
+    )

--- a/tests/prowjobsscraper/test_scraper.py
+++ b/tests/prowjobsscraper/test_scraper.py
@@ -202,9 +202,17 @@ def test_should_index_usage():
     event_store = MagicMock()
     event_store.scan_usages_identifiers.return_value = {
         equinix_usages.EquinixUsageIdentifier(
+            name="ipi-ci-op-5dp48qkr-3ce1b-1638692274747478016",
+            plan="c3.medium.x86",
+        ),
+        equinix_usages.EquinixUsageIdentifier(
+            name="ipi-ci-op-5dp48qkr-3ce1b-1638692274747478016",
+            plan="Outbound Bandwidth",
+        ),
+        equinix_usages.EquinixUsageIdentifier(
             name="ipi-ci-op-0wirr6qy-185f0-1638673073035022336",
             plan="c3.medium.x86",
-        )
+        ),
     }
 
     step_extractor = MagicMock()
@@ -212,12 +220,6 @@ def test_should_index_usage():
 
     equinix_metadata_extractor = MagicMock()
     equinix_usages_extractor = MagicMock()
-    equinix_usages_extractor._start_time = datetime(
-        year=2023, month=3, day=22, hour=22, minute=0, second=0, tzinfo=timezone.utc
-    )
-    equinix_usages_extractor._end_time = datetime(
-        year=2023, month=3, day=23, hour=5, minute=0, second=0, tzinfo=timezone.utc
-    )
     equinix_usages_extractor.get_project_usages.return_value = [
         equinix_usages.EquinixUsage.parse_obj(usage) for usage in usages
     ]


### PR DESCRIPTION
Currently, bandwidth usages are obtained from the `Equinix` API using the `start_date` and `end_date` that align with the requested time interval for the API. However, we aim to adjust their time to align with their corresponding non-bandwidth counterpart. This adjustment will allow them to be grouped together in the reports.