### PR TITLE
NO-ISSUE: Ignoring private jobs in Prow

### DIFF
--- a/src/prowjobsscraper/prowjob.py
+++ b/src/prowjobsscraper/prowjob.py
@@ -64,6 +64,7 @@ class ProwJobRef(BaseModel):
 class ProwJobSpec(BaseModel):
     job: str
     type: str
+    hidden: Optional[bool]
     extra_refs: Optional[list[ProwJobRef]]
 
 

--- a/src/prowjobsscraper/scraper.py
+++ b/src/prowjobsscraper/scraper.py
@@ -65,6 +65,8 @@ class Scraper:
 
     @staticmethod
     def _is_assisted_job(j: prowjob.ProwJob) -> bool:
+        if j.spec.hidden:
+            return False
         if j.status.state not in ("success", "failure"):
             return False
         elif not re.search("openshift.*assisted", j.spec.job):

--- a/tests/prowjobsscraper/prowjob_assets/expected_prowjobs.json
+++ b/tests/prowjobsscraper/prowjob_assets/expected_prowjobs.json
@@ -16,6 +16,7 @@
       "spec": {
         "job": "pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted",
         "type": "presubmit",
+        "hidden": null,
         "extra_refs": [
           {
             "org": "openshift",

--- a/tests/prowjobsscraper/test_prowjob.py
+++ b/tests/prowjobsscraper/test_prowjob.py
@@ -32,6 +32,7 @@ def test_valid_json_from_prow_should_be_successfully_parsed(httpserver: HTTPServ
     )
     httpserver.expect_request("/jobs").respond_with_data(response)
     jobs = prowjob.ProwJobs.create_from_url(httpserver.url_for("/jobs"))
+
     assert jobs.json() == json.dumps(expected)
 
 


### PR DESCRIPTION
Fix scraper to take only public jobs from `Prow`