### PR TITLE
MGMT-13338: Adding trends over time

### DIFF
--- a/src/jobsautoreport/trends.py
+++ b/src/jobsautoreport/trends.py
@@ -1,0 +1,49 @@
+from typing import Final, Optional
+
+from pydantic import BaseModel
+
+from jobsautoreport.report import Report
+
+COMPARED_FIELDS: Final[list[str]] = [
+    "number_of_e2e_or_subsystem_periodic_jobs",
+    "success_rate_for_e2e_or_subsystem_periodic_jobs",
+    "number_of_e2e_or_subsystem_presubmit_jobs",
+    "success_rate_for_e2e_or_subsystem_presubmit_jobs",
+    "number_of_rehearsal_jobs",
+    "number_of_postsubmit_jobs",
+    "success_rate_for_postsubmit_jobs",
+    "total_number_of_machine_leased",
+    "number_of_unsuccessful_machine_leases",
+    "total_equinix_machines_cost",
+]
+
+
+class Trends(BaseModel):
+    number_of_e2e_or_subsystem_periodic_jobs: int
+    success_rate_for_e2e_or_subsystem_periodic_jobs: Optional[float]
+    number_of_e2e_or_subsystem_presubmit_jobs: int
+    success_rate_for_e2e_or_subsystem_presubmit_jobs: Optional[float]
+    number_of_rehearsal_jobs: int
+    number_of_postsubmit_jobs: int
+    success_rate_for_postsubmit_jobs: Optional[float]
+    total_number_of_machine_leased: int
+    number_of_unsuccessful_machine_leases: int
+    total_equinix_machines_cost: float
+
+
+class TrendDetector(BaseModel):
+    current_report: Report
+    last_report: Report
+
+    def detect_trends(self) -> Trends:
+        trends = {}
+
+        for field in COMPARED_FIELDS:
+            if (
+                current_report_field_value := getattr(self.current_report, field)
+            ) is not None and (
+                last_report_field_value := getattr(self.last_report, field)
+            ) is not None:
+                trends[field] = current_report_field_value - last_report_field_value
+
+        return Trends.parse_obj(trends)

--- a/tests/jobsautoreport/test_slack.py
+++ b/tests/jobsautoreport/test_slack.py
@@ -1,393 +1,438 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, Callable
 from unittest.mock import MagicMock
+
+import pytest
 
 from jobsautoreport.models import JobMetrics, JobTypeMetrics, MachineMetrics
 from jobsautoreport.report import IdentifiedJobMetrics, JobIdentifier, Report
 from jobsautoreport.slack import SlackReporter
-
-report_1 = Report(
-    from_date=datetime.now(),
-    to_date=datetime.now(),
-    number_of_e2e_or_subsystem_periodic_jobs=12,
-    number_of_successful_e2e_or_subsystem_periodic_jobs=9,
-    number_of_failing_e2e_or_subsystem_periodic_jobs=3,
-    success_rate_for_e2e_or_subsystem_periodic_jobs=75,
-    top_10_failing_e2e_or_subsystem_periodic_jobs=[
-        # same variant
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="pull-ci-openshift-repo-branch-variant-context-1",
-                repository="repo",
-                base_ref="branch",
-                variant="variant",
-                context="context-1",
-            ),
-            metrics=JobMetrics(successes=3, failures=1, cost=0),
-        ),
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="pull-ci-openshift-repo-branch-variant-context-2",
-                repository="repo",
-                base_ref="branch",
-                variant="variant",
-                context="context-2",
-            ),
-            metrics=JobMetrics(successes=3, failures=1, cost=0),
-        ),
-    ],
-    number_of_e2e_or_subsystem_presubmit_jobs=24,
-    number_of_successful_e2e_or_subsystem_presubmit_jobs=8,
-    number_of_failing_e2e_or_subsystem_presubmit_jobs=16,
-    number_of_rehearsal_jobs=0,
-    success_rate_for_e2e_or_subsystem_presubmit_jobs=33.33,
-    top_10_failing_e2e_or_subsystem_presubmit_jobs=[
-        # different variant
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="pull-ci-openshift-repo-branch-variant-1-context-3",
-                repository="repo",
-                base_ref="branch",
-                variant="variant-1",
-                context="context-3",
-            ),
-            metrics=JobMetrics(successes=1, failures=2, cost=1),
-        ),
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="pull-ci-openshift-repo-branch-variant-2-context-4",
-                repository="repo",
-                base_ref="branch",
-                variant="variant-2",
-                context="context-4",
-            ),
-            metrics=JobMetrics(successes=1, failures=2, cost=1),
-        ),
-    ],
-    top_5_most_triggered_e2e_or_subsystem_jobs=[
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="fake-job-2", repository="test", base_ref="test"
-            ),
-            metrics=JobMetrics(successes=1, failures=2, cost=1),
-        ),
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="fake-job-1", repository="test", base_ref="test"
-            ),
-            metrics=JobMetrics(successes=3, failures=1, cost=1),
-        ),
-    ],
-    number_of_postsubmit_jobs=12,
-    number_of_successful_postsubmit_jobs=9,
-    number_of_failing_postsubmit_jobs=3,
-    success_rate_for_postsubmit_jobs=75,
-    top_10_failing_postsubmit_jobs=[
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="fake-job-3", repository="test", base_ref="test"
-            ),
-            metrics=JobMetrics(successes=3, failures=1, cost=1),
-        )
-    ],
-    number_of_successful_machine_leases=1,
-    number_of_unsuccessful_machine_leases=2,
-    total_number_of_machine_leased=3,
-    total_equinix_machines_cost=10,
-    cost_by_machine_type=MachineMetrics(
-        metrics={"m3.large.x86": 10, "c3.medium.x86": 5}
-    ),
-    cost_by_job_type=JobTypeMetrics(metrics={"postsubmit": 4}),
-    top_5_most_expensive_jobs=[
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="fake-job-3", repository="test", base_ref="test"
-            ),
-            metrics=JobMetrics(successes=3, failures=1, cost=1),
-        )
-    ],
-)
-
-report_2 = Report(
-    from_date=datetime.now(),
-    to_date=datetime.now(),
-    number_of_e2e_or_subsystem_periodic_jobs=0,
-    number_of_successful_e2e_or_subsystem_periodic_jobs=0,
-    number_of_failing_e2e_or_subsystem_periodic_jobs=0,
-    success_rate_for_e2e_or_subsystem_periodic_jobs=None,
-    top_10_failing_e2e_or_subsystem_periodic_jobs=[],
-    number_of_e2e_or_subsystem_presubmit_jobs=24,
-    number_of_successful_e2e_or_subsystem_presubmit_jobs=8,
-    number_of_failing_e2e_or_subsystem_presubmit_jobs=16,
-    number_of_rehearsal_jobs=0,
-    success_rate_for_e2e_or_subsystem_presubmit_jobs=33.33,
-    top_10_failing_e2e_or_subsystem_presubmit_jobs=[
-        # different variant
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="pull-ci-openshift-repo-branch-variant-1-context-3",
-                repository="repo",
-                base_ref="branch",
-                variant="variant-1",
-                context="context-3",
-            ),
-            metrics=JobMetrics(successes=1, failures=2, cost=3),
-        ),
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="pull-ci-openshift-repo-branch-variant-2-context-4",
-                repository="repo",
-                base_ref="branch",
-                variant="variant-2",
-                context="context-4",
-            ),
-            metrics=JobMetrics(successes=1, failures=2, cost=3),
-        ),
-    ],
-    top_5_most_triggered_e2e_or_subsystem_jobs=[
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="fake-job-2", repository="test", base_ref="test"
-            ),
-            metrics=JobMetrics(successes=1, failures=2, cost=3),
-        ),
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="fake-job-1", repository="test", base_ref="test"
-            ),
-            metrics=JobMetrics(successes=3, failures=1, cost=4),
-        ),
-    ],
-    number_of_postsubmit_jobs=0,
-    number_of_successful_postsubmit_jobs=0,
-    number_of_failing_postsubmit_jobs=0,
-    success_rate_for_postsubmit_jobs=None,
-    top_10_failing_postsubmit_jobs=[
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="fake-job-3", repository="test", base_ref="test"
-            ),
-            metrics=JobMetrics(successes=3, failures=1, cost=4),
-        )
-    ],
-    number_of_successful_machine_leases=1,
-    number_of_unsuccessful_machine_leases=2,
-    total_number_of_machine_leased=3,
-    total_equinix_machines_cost=10,
-    cost_by_machine_type=MachineMetrics(
-        metrics={"m3.large.x86": 10, "c3.medium.x86": 5}
-    ),
-    cost_by_job_type=JobTypeMetrics(metrics={"postsubmit": 4}),
-    top_5_most_expensive_jobs=[
-        IdentifiedJobMetrics(
-            job_identifier=JobIdentifier(
-                name="fake-job-3", repository="test", base_ref="test"
-            ),
-            metrics=JobMetrics(successes=3, failures=1, cost=1),
-        )
-    ],
-)
+from jobsautoreport.trends import Trends
 
 
-def expected_blocks(report: Report) -> dict[str, list[dict[str, Any]]]:
-    res = {}
-
-    res["expected_blocks_header"] = [
-        {
-            "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": "CI Report",
-                "emoji": True,
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"*{report.from_date.strftime('%Y-%m-%d %H:%M:%S')} UTC\t:arrow_right:\t{report.to_date.strftime('%Y-%m-%d %H:%M:%S')} UTC*\n",
-            },
-        },
-    ]
-
-    if report.success_rate_for_e2e_or_subsystem_periodic_jobs is not None:
-        res["expected_blocks_periodic"] = [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "*Periodic e2e/subsystem jobs*\n",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": (
-                        f"•\t _{report.number_of_e2e_or_subsystem_periodic_jobs}_ in total\n"
-                        f" \t\t *-* :done-circle-check: {report.number_of_successful_e2e_or_subsystem_periodic_jobs} succeeded\n"
-                        f" \t\t *-* :x: {report.number_of_failing_e2e_or_subsystem_periodic_jobs} failed\n"
-                        f" \t  _{report.success_rate_for_e2e_or_subsystem_periodic_jobs:.2f}%_ *success rate*\n"
-                    ),
-                },
-            },
-        ]
-
-    if report.success_rate_for_e2e_or_subsystem_presubmit_jobs is not None:
-        res["expected_blocks_presubmit"] = [
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "*Presubmit e2e/subsystem jobs*\n",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": (
-                        f"•\t _{report.number_of_e2e_or_subsystem_presubmit_jobs}_ in total\n"
-                        f" \t\t *-* :done-circle-check: {report.number_of_successful_e2e_or_subsystem_presubmit_jobs} succeeded\n"
-                        f" \t\t *-* :x: {report.number_of_failing_e2e_or_subsystem_presubmit_jobs} failed\n"
-                        f" \t  _{report.success_rate_for_e2e_or_subsystem_presubmit_jobs:.2f}%_ *success rate*\n"
-                    ),
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"•\t _{report.number_of_rehearsal_jobs}_ rehearsal jobs triggered",
-                },
-            },
-        ]
-
-    if report.success_rate_for_postsubmit_jobs is not None:
-        res["expected_blocks_postsubmit"] = [
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "*Postsubmit jobs*\n",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": (
-                        f"•\t _{report.number_of_postsubmit_jobs}_ in total\n"
-                        f" \t\t *-* :done-circle-check: {report.number_of_successful_postsubmit_jobs} succeeded\n"
-                        f" \t\t *-* :x: {report.number_of_failing_postsubmit_jobs} failed\n"
-                        f" \t  _{report.success_rate_for_postsubmit_jobs:.2f}%_ *success rate*\n"
-                    ),
-                },
-            },
-        ]
-
-    if report.total_equinix_machines_cost > 0:
-        res["expected_blocks_equinix"] = [
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "*Equinix*",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": (
-                        f"•\t _{report.total_number_of_machine_leased}_ machine lease attempts\n"
-                        f" \t\t *-* :done-circle-check: {report.number_of_successful_machine_leases} succeeded\n"
-                        f" \t\t *-* :x: {report.number_of_unsuccessful_machine_leases} failed\n"
-                    ),
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"•\t Total cost: *_{int(report.total_equinix_machines_cost)}_ $*  ",
-                },
-            },
-        ]
-
-    return res
+@pytest.fixture
+def test_thread_time_stamp() -> dict[str, str]:
+    return {"ts": "test-thread-time-stamp"}
 
 
-def test_send_report_should_successfully_call_slack_api_with_expected_message_format():
-    blocks = expected_blocks(report_1)
+@pytest.fixture
+def slack_reporter(test_thread_time_stamp) -> SlackReporter:
     test_channel = "test-channel"
-    test_thread_time_stamp = {"ts": "test-thread-time-stamp"}
     web_client_mock = MagicMock()
-    web_client_mock._create_quantity_image.return_value = None
-    web_client_mock._create_success_image.return_value = None
     response_mock = MagicMock()
     response_mock.validate.return_value = True
     response_mock.__getitem__.side_effect = test_thread_time_stamp.__getitem__
     web_client_mock.chat_postMessage.return_value = response_mock
     web_client_mock.files_upload.return_value = response_mock
-    slack_reporter = SlackReporter(web_client=web_client_mock, channel_id=test_channel)
-    slack_reporter.send_report(report_1)
-    web_client_mock.chat_postMessage.assert_any_call(
-        channel=test_channel, blocks=blocks["expected_blocks_header"], thread_ts=None
+
+    return SlackReporter(web_client=web_client_mock, channel_id=test_channel)
+
+
+@pytest.fixture
+def trends() -> Trends:
+    return Trends(
+        number_of_e2e_or_subsystem_periodic_jobs=10,
+        success_rate_for_e2e_or_subsystem_periodic_jobs=0.03,
+        number_of_e2e_or_subsystem_presubmit_jobs=5,
+        success_rate_for_e2e_or_subsystem_presubmit_jobs=None,
+        number_of_rehearsal_jobs=0,
+        number_of_postsubmit_jobs=5,
+        success_rate_for_postsubmit_jobs=-0.02,
+        total_number_of_machine_leased=50,
+        number_of_unsuccessful_machine_leases=-3,
+        total_equinix_machines_cost=1000,
     )
-    web_client_mock.chat_postMessage.assert_any_call(
-        channel=test_channel,
+
+
+@pytest.fixture
+def report_1() -> Report:
+    return Report(
+        from_date=datetime.now(),
+        to_date=datetime.now(),
+        number_of_e2e_or_subsystem_periodic_jobs=12,
+        number_of_successful_e2e_or_subsystem_periodic_jobs=9,
+        number_of_failing_e2e_or_subsystem_periodic_jobs=3,
+        success_rate_for_e2e_or_subsystem_periodic_jobs=75,
+        top_10_failing_e2e_or_subsystem_periodic_jobs=[
+            # same variant
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="pull-ci-openshift-repo-branch-variant-context-1",
+                    repository="repo",
+                    base_ref="branch",
+                    variant="variant",
+                    context="context-1",
+                ),
+                metrics=JobMetrics(successes=3, failures=1, cost=0),
+            ),
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="pull-ci-openshift-repo-branch-variant-context-2",
+                    repository="repo",
+                    base_ref="branch",
+                    variant="variant",
+                    context="context-2",
+                ),
+                metrics=JobMetrics(successes=3, failures=1, cost=0),
+            ),
+        ],
+        number_of_e2e_or_subsystem_presubmit_jobs=24,
+        number_of_successful_e2e_or_subsystem_presubmit_jobs=8,
+        number_of_failing_e2e_or_subsystem_presubmit_jobs=16,
+        number_of_rehearsal_jobs=0,
+        success_rate_for_e2e_or_subsystem_presubmit_jobs=33.33,
+        top_10_failing_e2e_or_subsystem_presubmit_jobs=[
+            # different variant
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="pull-ci-openshift-repo-branch-variant-1-context-3",
+                    repository="repo",
+                    base_ref="branch",
+                    variant="variant-1",
+                    context="context-3",
+                ),
+                metrics=JobMetrics(successes=1, failures=2, cost=1),
+            ),
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="pull-ci-openshift-repo-branch-variant-2-context-4",
+                    repository="repo",
+                    base_ref="branch",
+                    variant="variant-2",
+                    context="context-4",
+                ),
+                metrics=JobMetrics(successes=1, failures=2, cost=1),
+            ),
+        ],
+        top_5_most_triggered_e2e_or_subsystem_jobs=[
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="fake-job-2", repository="test", base_ref="test"
+                ),
+                metrics=JobMetrics(successes=1, failures=2, cost=1),
+            ),
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="fake-job-1", repository="test", base_ref="test"
+                ),
+                metrics=JobMetrics(successes=3, failures=1, cost=1),
+            ),
+        ],
+        number_of_postsubmit_jobs=12,
+        number_of_successful_postsubmit_jobs=9,
+        number_of_failing_postsubmit_jobs=3,
+        success_rate_for_postsubmit_jobs=75,
+        top_10_failing_postsubmit_jobs=[
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="fake-job-3", repository="test", base_ref="test"
+                ),
+                metrics=JobMetrics(successes=3, failures=1, cost=1),
+            )
+        ],
+        number_of_successful_machine_leases=1,
+        number_of_unsuccessful_machine_leases=2,
+        total_number_of_machine_leased=3,
+        total_equinix_machines_cost=10,
+        cost_by_machine_type=MachineMetrics(
+            metrics={"m3.large.x86": 10, "c3.medium.x86": 5}
+        ),
+        cost_by_job_type=JobTypeMetrics(metrics={"postsubmit": 4}),
+        top_5_most_expensive_jobs=[
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="fake-job-3", repository="test", base_ref="test"
+                ),
+                metrics=JobMetrics(successes=3, failures=1, cost=1),
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def report_2() -> Report:
+    return Report(
+        from_date=datetime.now(),
+        to_date=datetime.now(),
+        number_of_e2e_or_subsystem_periodic_jobs=0,
+        number_of_successful_e2e_or_subsystem_periodic_jobs=0,
+        number_of_failing_e2e_or_subsystem_periodic_jobs=0,
+        success_rate_for_e2e_or_subsystem_periodic_jobs=None,
+        top_10_failing_e2e_or_subsystem_periodic_jobs=[],
+        number_of_e2e_or_subsystem_presubmit_jobs=24,
+        number_of_successful_e2e_or_subsystem_presubmit_jobs=8,
+        number_of_failing_e2e_or_subsystem_presubmit_jobs=16,
+        number_of_rehearsal_jobs=0,
+        success_rate_for_e2e_or_subsystem_presubmit_jobs=33.33,
+        top_10_failing_e2e_or_subsystem_presubmit_jobs=[
+            # different variant
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="pull-ci-openshift-repo-branch-variant-1-context-3",
+                    repository="repo",
+                    base_ref="branch",
+                    variant="variant-1",
+                    context="context-3",
+                ),
+                metrics=JobMetrics(successes=1, failures=2, cost=3),
+            ),
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="pull-ci-openshift-repo-branch-variant-2-context-4",
+                    repository="repo",
+                    base_ref="branch",
+                    variant="variant-2",
+                    context="context-4",
+                ),
+                metrics=JobMetrics(successes=1, failures=2, cost=3),
+            ),
+        ],
+        top_5_most_triggered_e2e_or_subsystem_jobs=[
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="fake-job-2", repository="test", base_ref="test"
+                ),
+                metrics=JobMetrics(successes=1, failures=2, cost=3),
+            ),
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="fake-job-1", repository="test", base_ref="test"
+                ),
+                metrics=JobMetrics(successes=3, failures=1, cost=4),
+            ),
+        ],
+        number_of_postsubmit_jobs=0,
+        number_of_successful_postsubmit_jobs=0,
+        number_of_failing_postsubmit_jobs=0,
+        success_rate_for_postsubmit_jobs=None,
+        top_10_failing_postsubmit_jobs=[
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="fake-job-3", repository="test", base_ref="test"
+                ),
+                metrics=JobMetrics(successes=3, failures=1, cost=4),
+            )
+        ],
+        number_of_successful_machine_leases=1,
+        number_of_unsuccessful_machine_leases=2,
+        total_number_of_machine_leased=3,
+        total_equinix_machines_cost=10,
+        cost_by_machine_type=MachineMetrics(
+            metrics={"m3.large.x86": 10, "c3.medium.x86": 5}
+        ),
+        cost_by_job_type=JobTypeMetrics(metrics={"postsubmit": 4}),
+        top_5_most_expensive_jobs=[
+            IdentifiedJobMetrics(
+                job_identifier=JobIdentifier(
+                    name="fake-job-3", repository="test", base_ref="test"
+                ),
+                metrics=JobMetrics(successes=3, failures=1, cost=1),
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def expected_blocks() -> Callable[[Report, Trends], dict[str, list[dict[str, Any]]]]:
+    def func(report: Report, trends: Trends) -> dict[str, list[dict[str, Any]]]:
+        res = {}
+
+        res["expected_blocks_header"] = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "CI Report",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*{report.from_date.strftime('%Y-%m-%d %H:%M:%S')} UTC\t:arrow_right:\t{report.to_date.strftime('%Y-%m-%d %H:%M:%S')} UTC*\n",
+                },
+            },
+        ]
+
+        if report.success_rate_for_e2e_or_subsystem_periodic_jobs is not None:
+            res["expected_blocks_periodic"] = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Periodic e2e/subsystem jobs*\n",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"•\t _{report.number_of_e2e_or_subsystem_periodic_jobs}_ in total :arrow_upper_right:  {trends.number_of_e2e_or_subsystem_periodic_jobs}\n"
+                            f" \t\t *-* :done-circle-check: {report.number_of_successful_e2e_or_subsystem_periodic_jobs} succeeded\n"
+                            f" \t\t *-* :x: {report.number_of_failing_e2e_or_subsystem_periodic_jobs} failed\n"
+                            f" \t  _{report.success_rate_for_e2e_or_subsystem_periodic_jobs:.2f}%_ *success rate* :arrow_upper_right:  {trends.success_rate_for_e2e_or_subsystem_periodic_jobs}%\n"
+                        ),
+                    },
+                },
+            ]
+
+        if report.success_rate_for_e2e_or_subsystem_presubmit_jobs is not None:
+            res["expected_blocks_presubmit"] = [
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Presubmit e2e/subsystem jobs*\n",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"•\t _{report.number_of_e2e_or_subsystem_presubmit_jobs}_ in total :arrow_upper_right:  {trends.number_of_e2e_or_subsystem_presubmit_jobs}\n"
+                            f" \t\t *-* :done-circle-check: {report.number_of_successful_e2e_or_subsystem_presubmit_jobs} succeeded\n"
+                            f" \t\t *-* :x: {report.number_of_failing_e2e_or_subsystem_presubmit_jobs} failed\n"
+                            f" \t  _{report.success_rate_for_e2e_or_subsystem_presubmit_jobs:.2f}%_ *success rate*\n"
+                        ),
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"•\t _{report.number_of_rehearsal_jobs}_ rehearsal jobs triggered :arrow_right:  {trends.number_of_rehearsal_jobs}",
+                    },
+                },
+            ]
+
+        if report.success_rate_for_postsubmit_jobs is not None:
+            res["expected_blocks_postsubmit"] = [
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Postsubmit jobs*\n",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"•\t _{report.number_of_postsubmit_jobs}_ in total :arrow_upper_right:  {trends.number_of_postsubmit_jobs}\n"
+                            f" \t\t *-* :done-circle-check: {report.number_of_successful_postsubmit_jobs} succeeded\n"
+                            f" \t\t *-* :x: {report.number_of_failing_postsubmit_jobs} failed\n"
+                            f" \t  _{report.success_rate_for_postsubmit_jobs:.2f}%_ *success rate* :arrow_lower_right:  {trends.success_rate_for_postsubmit_jobs}%\n"
+                        ),
+                    },
+                },
+            ]
+
+        if report.total_equinix_machines_cost > 0:
+            res["expected_blocks_equinix"] = [
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Equinix*",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"•\t _{report.total_number_of_machine_leased}_ machine lease attempts :arrow_upper_right:  {trends.total_number_of_machine_leased}\n"
+                            f" \t\t *-* :done-circle-check: {report.number_of_successful_machine_leases} succeeded\n"
+                            f" \t\t *-* :x: {report.number_of_unsuccessful_machine_leases} failed :arrow_lower_right:  {trends.number_of_unsuccessful_machine_leases}\n"
+                        ),
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"•\t Total cost: *_{int(report.total_equinix_machines_cost)}_ $* :arrow_upper_right:  {int(trends.total_equinix_machines_cost)} $",
+                    },
+                },
+            ]
+
+        return res
+
+    return func
+
+
+def test_send_report_should_successfully_call_slack_api_with_expected_message_format(
+    report_1: Report,
+    expected_blocks: Callable[[Report, Trends], dict[str, list[dict[str, Any]]]],
+    test_thread_time_stamp: dict[str, str],
+    trends: Trends,
+    slack_reporter: SlackReporter,
+):
+    blocks = expected_blocks(report_1, trends)
+    slack_reporter.send_report(report_1, trends)
+
+    slack_reporter._client.chat_postMessage.assert_any_call(
+        channel=slack_reporter._channel_id,
+        blocks=blocks["expected_blocks_header"],
+        thread_ts=None,
+    )
+    slack_reporter._client.chat_postMessage.assert_any_call(
+        channel=slack_reporter._channel_id,
         blocks=blocks["expected_blocks_periodic"],
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/top_10_failed_periodic_jobs.png",
         filename="top_10_failed_periodic_jobs",
         initial_comment="Top 10 Failed Periodic Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.chat_postMessage.assert_any_call(
-        channel=test_channel,
+    slack_reporter._client.chat_postMessage.assert_any_call(
+        channel=slack_reporter._channel_id,
         blocks=blocks["expected_blocks_presubmit"],
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/top_10_failed_presubmit_jobs.png",
         filename="top_10_failed_presubmit_jobs",
         initial_comment="Top 10 Failed Presubmit Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/top_5_triggered_presubmit_jobs.png",
         filename="top_5_triggered_presubmit_jobs",
         initial_comment="Top 5 Triggered Presubmit Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.chat_postMessage.assert_any_call(
-        channel=test_channel,
+    slack_reporter._client.chat_postMessage.assert_any_call(
+        channel=slack_reporter._channel_id,
         blocks=blocks["expected_blocks_postsubmit"],
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/top_10_failed_postsubmit_jobs.png",
         filename="top_10_failed_postsubmit_jobs",
         initial_comment="Top 10 Failed Postsubmit Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.chat_postMessage.assert_any_call(
-        channel=test_channel,
+    slack_reporter._client.chat_postMessage.assert_any_call(
+        channel=slack_reporter._channel_id,
         blocks=blocks["expected_blocks_equinix"],
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/top_5_most_expensive_jobs.png",
         filename="top_5_most_expensive_jobs",
         initial_comment="Top 5 Most Expensive Jobs",
@@ -395,64 +440,61 @@ def test_send_report_should_successfully_call_slack_api_with_expected_message_fo
     )
 
 
-def test_send_report_should_successfully_call_slack_api_with_filtering_none_success_rates():
-    blocks = expected_blocks(report_2)
-    test_channel = "test-channel"
-    test_thread_time_stamp = {"ts": "test-thread-time-stamp"}
-    web_client_mock = MagicMock()
-    web_client_mock._create_quantity_image.return_value = None
-    web_client_mock._create_success_image.return_value = None
-    response_mock = MagicMock()
-    response_mock.validate.return_value = True
-    response_mock.__getitem__.side_effect = test_thread_time_stamp.__getitem__
-    web_client_mock.chat_postMessage.return_value = response_mock
-    web_client_mock.files_upload.return_value = response_mock
-    slack_reporter = SlackReporter(web_client=web_client_mock, channel_id=test_channel)
-    slack_reporter.send_report(report_2)
+def test_send_report_should_successfully_call_slack_api_with_filtering_none_success_rates(
+    report_2: Report,
+    expected_blocks: Callable[[Report, Trends], dict[str, list[dict[str, Any]]]],
+    test_thread_time_stamp: dict[str, str],
+    trends: Trends,
+    slack_reporter: SlackReporter,
+):
+    blocks = expected_blocks(report_2, trends)
+    slack_reporter.send_report(report_2, trends)
 
-    web_client_mock.chat_postMessage.assert_any_call(
-        channel=test_channel, blocks=blocks["expected_blocks_header"], thread_ts=None
+    slack_reporter._client.chat_postMessage.assert_any_call(
+        channel=slack_reporter._channel_id,
+        blocks=blocks["expected_blocks_header"],
+        thread_ts=None,
     )
-    web_client_mock.chat_postMessage.assert_any_call(
-        channel=test_channel,
+    slack_reporter._client.chat_postMessage.assert_any_call(
+        channel=slack_reporter._channel_id,
         blocks=blocks["expected_blocks_presubmit"],
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/top_10_failed_presubmit_jobs.png",
         filename="top_10_failed_presubmit_jobs",
         initial_comment="Top 10 Failed Presubmit Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/top_5_triggered_presubmit_jobs.png",
         filename="top_5_triggered_presubmit_jobs",
         initial_comment="Top 5 Triggered Presubmit Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.chat_postMessage.assert_any_call(
-        channel=test_channel,
+    slack_reporter._client.chat_postMessage.assert_any_call(
+        channel=slack_reporter._channel_id,
         blocks=blocks["expected_blocks_equinix"],
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/top_5_most_expensive_jobs.png",
         filename="top_5_most_expensive_jobs",
         initial_comment="Top 5 Most Expensive Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/cost_by_machine_type.png",
         filename="cost_by_machine_type",
         initial_comment="Cost by Machine Type",
         thread_ts=test_thread_time_stamp["ts"],
     )
-    web_client_mock.files_upload.assert_any_call(
-        channels=[test_channel],
+    slack_reporter._client.files_upload.assert_any_call(
+        channels=[slack_reporter._channel_id],
         file="/tmp/cost_by_job_type.png",
         filename="cost_by_job_type",
         initial_comment="Cost by Job Type",
@@ -460,7 +502,7 @@ def test_send_report_should_successfully_call_slack_api_with_filtering_none_succ
     )
 
 
-def test_JobIdentifier_short_names_in_slack():
+def test_JobIdentifier_short_names_in_slack(report_1):
     expected_top_10_failing_e2e_or_subsystem_periodic_jobs_slack_names = [
         "repo/branch<br>context-1",
         "repo/branch<br>context-2",
@@ -532,3 +574,10 @@ def test_format_cost_by_job_type_metrics():
     )
     assert types == ["Others", "batch", "presubmit"]
     assert costs == [10, 1000, 500]
+
+
+def test_get_arrow_for_trend():
+    slack_reporter = SlackReporter(web_client=MagicMock(), channel_id=MagicMock())
+    assert slack_reporter._get_arrow_for_trend(trend=1) == "arrow_upper_right"
+    assert slack_reporter._get_arrow_for_trend(trend=0) == "arrow_right"
+    assert slack_reporter._get_arrow_for_trend(trend=-1) == "arrow_lower_right"

--- a/tests/jobsautoreport/test_trends.py
+++ b/tests/jobsautoreport/test_trends.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from jobsautoreport.models import JobTypeMetrics, MachineMetrics
+from jobsautoreport.report import Report
+from jobsautoreport.trends import TrendDetector, Trends
+
+mock_list = MagicMock(return_value=[1, 2, 3])
+
+
+@pytest.fixture
+def mock_current_report():
+    return Report(
+        from_date=datetime.now(),
+        to_date=datetime.now(),
+        number_of_e2e_or_subsystem_periodic_jobs=0,
+        number_of_successful_e2e_or_subsystem_periodic_jobs=0,
+        number_of_failing_e2e_or_subsystem_periodic_jobs=0,
+        success_rate_for_e2e_or_subsystem_periodic_jobs=None,
+        top_10_failing_e2e_or_subsystem_periodic_jobs=[],
+        number_of_e2e_or_subsystem_presubmit_jobs=10,
+        number_of_successful_e2e_or_subsystem_presubmit_jobs=8,
+        number_of_failing_e2e_or_subsystem_presubmit_jobs=2,
+        number_of_rehearsal_jobs=4,
+        success_rate_for_e2e_or_subsystem_presubmit_jobs=0.8,
+        top_10_failing_e2e_or_subsystem_presubmit_jobs=[],
+        top_5_most_triggered_e2e_or_subsystem_jobs=[],
+        number_of_postsubmit_jobs=16,
+        number_of_successful_postsubmit_jobs=8,
+        number_of_failing_postsubmit_jobs=8,
+        success_rate_for_postsubmit_jobs=0.5,
+        top_10_failing_postsubmit_jobs=[],
+        number_of_successful_machine_leases=16,
+        number_of_unsuccessful_machine_leases=0,
+        total_number_of_machine_leased=16,
+        total_equinix_machines_cost=1000.0,
+        cost_by_machine_type=MachineMetrics(metrics={}),
+        cost_by_job_type=JobTypeMetrics(metrics={}),
+        top_5_most_expensive_jobs=[],
+    )
+
+
+@pytest.fixture
+def mock_last_report():
+    return Report(
+        from_date=datetime.now(),
+        to_date=datetime.now(),
+        number_of_e2e_or_subsystem_periodic_jobs=20,
+        number_of_successful_e2e_or_subsystem_periodic_jobs=15,
+        number_of_failing_e2e_or_subsystem_periodic_jobs=5,
+        success_rate_for_e2e_or_subsystem_periodic_jobs=0.75,
+        top_10_failing_e2e_or_subsystem_periodic_jobs=[],
+        number_of_e2e_or_subsystem_presubmit_jobs=10,
+        number_of_successful_e2e_or_subsystem_presubmit_jobs=8,
+        number_of_failing_e2e_or_subsystem_presubmit_jobs=2,
+        number_of_rehearsal_jobs=4,
+        success_rate_for_e2e_or_subsystem_presubmit_jobs=0.8,
+        top_10_failing_e2e_or_subsystem_presubmit_jobs=[],
+        top_5_most_triggered_e2e_or_subsystem_jobs=[],
+        number_of_postsubmit_jobs=0,
+        number_of_successful_postsubmit_jobs=0,
+        number_of_failing_postsubmit_jobs=0,
+        success_rate_for_postsubmit_jobs=None,
+        top_10_failing_postsubmit_jobs=[],
+        number_of_successful_machine_leases=16,
+        number_of_unsuccessful_machine_leases=0,
+        total_number_of_machine_leased=16,
+        total_equinix_machines_cost=1000.0,
+        cost_by_machine_type=MachineMetrics(metrics={}),
+        cost_by_job_type=JobTypeMetrics(metrics={}),
+        top_5_most_expensive_jobs=[],
+    )
+
+
+@pytest.fixture
+def mock_trend_detecter(mock_current_report: Report, mock_last_report: Report):
+    return TrendDetector(
+        current_report=mock_current_report,
+        last_report=mock_last_report,
+    )
+
+
+def test_detect_trends(
+    mock_trend_detecter: TrendDetector,
+    mock_current_report: Report,
+    mock_last_report: Report,
+):
+    trends = mock_trend_detecter.detect_trends()
+
+    assert (
+        trends.number_of_e2e_or_subsystem_periodic_jobs
+        == mock_current_report.number_of_e2e_or_subsystem_periodic_jobs
+        - mock_last_report.number_of_e2e_or_subsystem_periodic_jobs
+    )
+    assert trends.success_rate_for_e2e_or_subsystem_periodic_jobs is None
+    assert (
+        trends.number_of_e2e_or_subsystem_presubmit_jobs
+        == mock_current_report.number_of_e2e_or_subsystem_presubmit_jobs
+        - mock_last_report.number_of_e2e_or_subsystem_presubmit_jobs
+    )
+    assert (
+        trends.success_rate_for_e2e_or_subsystem_presubmit_jobs
+        == mock_current_report.success_rate_for_e2e_or_subsystem_presubmit_jobs
+        - mock_last_report.success_rate_for_e2e_or_subsystem_presubmit_jobs
+    )
+    assert (
+        trends.number_of_rehearsal_jobs
+        == mock_current_report.number_of_rehearsal_jobs
+        - mock_last_report.number_of_rehearsal_jobs
+    )
+    assert (
+        trends.number_of_postsubmit_jobs
+        == mock_current_report.number_of_postsubmit_jobs
+        - mock_last_report.number_of_postsubmit_jobs
+    )
+    assert trends.success_rate_for_postsubmit_jobs is None
+    assert (
+        trends.total_number_of_machine_leased
+        == mock_current_report.total_number_of_machine_leased
+        - mock_last_report.total_number_of_machine_leased
+    )
+    assert (
+        trends.number_of_unsuccessful_machine_leases
+        == mock_current_report.number_of_unsuccessful_machine_leases
+        - mock_last_report.number_of_unsuccessful_machine_leases
+    )


### PR DESCRIPTION
To track CI trends over time, I included a comparison of each report to its predecessor, focusing on specific attributes of interest.

for example -

![image](https://github.com/openshift-assisted/prow-jobs-scraper/assets/57135227/10f0275c-2bdf-4d87-b4a8-d081e5de0f5e)
