### PR TITLE
NO-ISSUE: Change flaky jobs in report to include only periodics

### DIFF
--- a/src/jobsautoreport/report.py
+++ b/src/jobsautoreport/report.py
@@ -440,6 +440,6 @@ class Reporter:
                 jobs=assisted_components_jobs, usages=usages, n=5
             ),
             flaky_jobs=self._get_flaky_jobs(
-                jobs=assisted_components_jobs, usages=usages
+                jobs=periodic_subsystem_and_e2e_jobs, usages=usages
             ),
         )

--- a/src/jobsautoreport/slack.py
+++ b/src/jobsautoreport/slack.py
@@ -152,10 +152,10 @@ class SlackReporter:
         if len(report.flaky_jobs) > 0:
             filename, file_path = plotter.create_flaky_jobs_graph(
                 jobs=report.flaky_jobs,
-                file_title="Flaky Jobs",
+                file_title="Periodic Flaky Jobs",
             )
             self._upload_file(
-                file_title="Flaky Jobs",
+                file_title="Periodic Flaky Jobs",
                 filename=filename,
                 file_path=file_path,
                 thread_time_stamp=thread_time_stamp,

--- a/tests/jobsautoreport/test_slack.py
+++ b/tests/jobsautoreport/test_slack.py
@@ -456,9 +456,9 @@ def test_send_report_should_successfully_call_slack_api_with_expected_message_fo
     )
     slack_reporter._client.files_upload.assert_any_call(
         channels=[slack_reporter._channel_id],
-        file="/tmp/flaky_jobs.png",
-        filename="flaky_jobs",
-        initial_comment="Flaky Jobs",
+        file="/tmp/periodic_flaky_jobs.png",
+        filename="periodic_flaky_jobs",
+        initial_comment="Periodic Flaky Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
 
@@ -521,13 +521,6 @@ def test_send_report_should_successfully_call_slack_api_with_filtering_none_succ
         file="/tmp/cost_by_job_type.png",
         filename="cost_by_job_type",
         initial_comment="Cost by Job Type",
-        thread_ts=test_thread_time_stamp["ts"],
-    )
-    slack_reporter._client.files_upload.assert_any_call(
-        channels=[slack_reporter._channel_id],
-        file="/tmp/flaky_jobs.png",
-        filename="flaky_jobs",
-        initial_comment="Flaky Jobs",
         thread_ts=test_thread_time_stamp["ts"],
     )
 


### PR DESCRIPTION
Change flaky jobs in report to include only `periodics`