### PR TITLE
MGMT-15767: Fix scraper's usages gathering

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -47,8 +47,6 @@ objects:
                 value: "${ES_USAGE_INDEX}"
               - name: JOB_LIST_URL
                 value: "${JOB_LIST_URL}"
-              - name: EQUINIX_USAGES_SCRAPE_INTERVAL
-                value: "${EQUINIX_USAGES_SCRAPE_INTERVAL}"
               - name: ES_USER
                 valueFrom:
                   secretKeyRef:
@@ -114,8 +112,6 @@ objects:
                 value: "${ES_USAGE_INDEX}"
               - name: JOB_LIST_URL
                 value: "${JOB_LIST_URL}"
-              - name: EQUINIX_USAGES_SCRAPE_INTERVAL
-                value: "${EQUINIX_USAGES_SCRAPE_INTERVAL}"
               - name: ES_USER
                 valueFrom:
                   secretKeyRef:
@@ -307,8 +303,6 @@ parameters:
   value: "false"
 - name: PROW_JOBS_SCRAPER_SCHEDULE
   value: "@hourly"
-- name: EQUINIX_USAGES_SCRAPE_INTERVAL
-  value: "day"
 - name: PROW_JOBS_SCRAPER_EQUINIX_SECRET_NAME
   value: prow-jobs-scraper-equinix-secret
 - name: PROW_JOBS_SCRAPER_EQUINIX_ASSISTED_PROJECT_ID_KEY

--- a/src/prowjobsscraper/config.py
+++ b/src/prowjobsscraper/config.py
@@ -1,7 +1,5 @@
 import os
 
-from prowjobsscraper.equinix_usages import EquinixUsagesScrapeInterval
-
 ES_URL = os.environ["ES_URL"]
 ES_USER = os.environ["ES_USER"]
 ES_PASSWORD = os.environ["ES_PASSWORD"]
@@ -12,6 +10,3 @@ JOB_LIST_URL = os.environ["JOB_LIST_URL"]
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 EQUINIX_PROJECT_ID = os.environ["EQUINIX_PROJECT_ID"]
 EQUINIX_PROJECT_TOKEN = os.environ["EQUINIX_PROJECT_TOKEN"]
-EQUINIX_USAGES_SCRAPE_INTERVAL = EquinixUsagesScrapeInterval(
-    os.environ["EQUINIX_USAGES_SCRAPE_INTERVAL"]
-)

--- a/src/prowjobsscraper/equinix_usages.py
+++ b/src/prowjobsscraper/equinix_usages.py
@@ -9,13 +9,6 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 
-class EquinixUsagesScrapeInterval(Enum):
-    HOUR = "hour"
-    DAY = "day"
-    WEEK = "week"
-    MONTH = "month"
-
-
 class EquinixUsageIdentifier(BaseModel):
     name: str
     plan: str

--- a/src/prowjobsscraper/main.py
+++ b/src/prowjobsscraper/main.py
@@ -40,23 +40,7 @@ def main() -> None:
     )
 
     usages_scrape_end_time = datetime.now(tz=timezone.utc)
-    if (
-        config.EQUINIX_USAGES_SCRAPE_INTERVAL
-        == equinix_usages.EquinixUsagesScrapeInterval.HOUR
-    ):
-        usages_scrape_start_time = usages_scrape_end_time - relativedelta(hours=1)
-    elif (
-        config.EQUINIX_USAGES_SCRAPE_INTERVAL
-        == equinix_usages.EquinixUsagesScrapeInterval.DAY
-    ):
-        usages_scrape_start_time = usages_scrape_end_time - relativedelta(days=1)
-    elif (
-        config.EQUINIX_USAGES_SCRAPE_INTERVAL
-        == equinix_usages.EquinixUsagesScrapeInterval.WEEK
-    ):
-        usages_scrape_start_time = usages_scrape_end_time - relativedelta(weeks=1)
-    else:
-        usages_scrape_start_time = usages_scrape_end_time - relativedelta(months=1)
+    usages_scrape_start_time = usages_scrape_end_time - relativedelta(weeks=1)
 
     equinix_usages_extractor = equinix_usages.EquinixUsagesExtractor(
         project_id=config.EQUINIX_PROJECT_ID,


### PR DESCRIPTION
Currently, data is collected from `equinix` API at varying intervals but is indexed on a weekly basis. This mismatch leads to some usages being indexed multiple times, damaging the accuracy of the `equinix` cost report. I am setting the usages gather interval to weekly as well.