### PR TITLE
NO-ISSUE: Disable cost by job type

### DIFF
--- a/src/jobsautoreport/slack/slack_report.py
+++ b/src/jobsautoreport/slack/slack_report.py
@@ -229,21 +229,6 @@ class SlackReporter:
                     file_path=file_path,
                     thread_time_stamp=thread_time_stamp,
                 )
-                labels, values = self._create_cost_by_job_type_metrics(
-                    report.equinix_cost_report.cost_by_job_type
-                )
-                filename, file_path = plotter.create_pie_chart(
-                    labels=labels,
-                    values=values,
-                    colors=PIE_CHART_COLORS,
-                    title=COST_BY_JOB_TYPE_TITLE,
-                )
-                self._upload_file(
-                    file_title=COST_BY_JOB_TYPE_TITLE,
-                    filename=filename,
-                    file_path=file_path,
-                    thread_time_stamp=thread_time_stamp,
-                )
 
     def send_report(
         self, report: Report, trends: Optional[Trends], feature_flags: FeatureFlags

--- a/tests/jobsautoreport/test_slack_report.py
+++ b/tests/jobsautoreport/test_slack_report.py
@@ -266,8 +266,8 @@ def test_send_report_with_all_features(
     # header, periodics, presubmits, postsubmits, equinix
     assert slack_reporter._client.chat_postMessage.call_count == 5
 
-    # 3 (top 10 failing) graphs, (top 5 triggered) graph, (flaky jobs) graph, 3 equinix graphs
-    assert slack_reporter._client.files_upload.call_count == 8
+    # 3 (top 10 failing) graphs, (top 5 triggered) graph, (flaky jobs) graph, 2 equinix graphs
+    assert slack_reporter._client.files_upload.call_count == 7
 
 
 def test_send_report_with_all_features_but_success_rate(
@@ -290,8 +290,8 @@ def test_send_report_with_all_features_but_success_rate(
     # header, equinix
     assert slack_reporter._client.chat_postMessage.call_count == 2
 
-    # (flaky jobs) graph, 3 equinix graphs
-    assert slack_reporter._client.files_upload.call_count == 4
+    # (flaky jobs) graph, 2 equinix graphs
+    assert slack_reporter._client.files_upload.call_count == 3
 
 
 def test_send_report_with_all_features_but_equinix_usage(
@@ -314,8 +314,8 @@ def test_send_report_with_all_features_but_equinix_usage(
     # header, periodics, presubmits, postsubmits, equinix (partial)
     assert slack_reporter._client.chat_postMessage.call_count == 5
 
-    # 3 (top 10 failing) graphs, (top 5 triggered) graph, (flaky jobs) graph, 3 equinix graphs
-    assert slack_reporter._client.files_upload.call_count == 8
+    # 3 (top 10 failing) graphs, (top 5 triggered) graph, (flaky jobs) graph, 2 equinix graphs
+    assert slack_reporter._client.files_upload.call_count == 7
 
 
 def test_send_report_with_all_features_but_equinix_cost(
@@ -362,8 +362,8 @@ def test_send_report_with_all_features_but_trends(
     # header, periodics, presubmits, postsubmits, equinix
     assert slack_reporter._client.chat_postMessage.call_count == 5
 
-    # 3 (top 10 failing) graphs, (top 5 triggered) graph, (flaky jobs) graph, 3 equinix graphs
-    assert slack_reporter._client.files_upload.call_count == 8
+    # 3 (top 10 failing) graphs, (top 5 triggered) graph, (flaky jobs) graph, 2 equinix graphs
+    assert slack_reporter._client.files_upload.call_count == 7
 
 
 def test_send_report_with_all_features_but_flakiness_rates(
@@ -386,8 +386,8 @@ def test_send_report_with_all_features_but_flakiness_rates(
     # header, periodics, presubmits, postsubmits, equinix
     assert slack_reporter._client.chat_postMessage.call_count == 5
 
-    # 3 (top 10 failing) graphs, (top 5 triggered) graph, 3 equinix graphs
-    assert slack_reporter._client.files_upload.call_count == 7
+    # 3 (top 10 failing) graphs, (top 5 triggered) graph, 2 equinix graphs
+    assert slack_reporter._client.files_upload.call_count == 6
 
 
 def test_format_cost_by_machine_type_metrics():


### PR DESCRIPTION
Disable the `cost by job type` graph until the source of the mismatch between jobs and usages is found, as it causes the graph to be inaccurate.