### PR TITLE
forbid concurrent execution to prevent errors piling up

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -8,6 +8,7 @@ objects:
   metadata:
     name: prow-jobs-scraper-assisted-project-usages
   spec:
+    concurrencyPolicy: ${PROW_JOBS_CONCURRENCY_POLICY}
     schedule: ${PROW_JOBS_SCRAPER_SCHEDULE}
     suspend: ${{PROW_JOBS_SCRAPER_SUSPEND}}
     jobTemplate:
@@ -345,3 +346,5 @@ parameters:
   value: "true"
 - name: FEATURE_FLAKINESS_RATES
   value: "true"
+- name: PROW_JOBS_CONCURRENCY_POLICY
+  value: "Forbid"


### PR DESCRIPTION
This will prevent crons execution piling up in case of errors resulting in pending pods i.e.