### PR TITLE
NO-ISSUE: Indexing in elasticsearch with a unique per-index manually set value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "retry==0.9.2",
     "pandas==2.1.1",
     "numpy==1.26.0",
+    "mmh3==4.0.1",
 ]
 dynamic = ["version"]
 

--- a/src/prowjobsscraper/utils.py
+++ b/src/prowjobsscraper/utils.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import mmh3
 from google.cloud import storage  # type: ignore
 from pydantic import HttpUrl
 
@@ -21,3 +22,9 @@ def download_from_gcs_as_string(client: storage.Client, bucket: str, path: str) 
     gcs_bucket = client.bucket(bucket)
     gcs_blob = gcs_bucket.blob(path)
     return gcs_blob.download_as_string()
+
+
+def generate_hash_from_strings(*strings) -> str:
+    joined_string = "".join(strings)
+    hashed_string = str(mmh3.hash(joined_string))
+    return hashed_string


### PR DESCRIPTION
Currently it is possible for two identical documents to be indexed in the same `elasticsearch` index because in case of parallel execution of `prow-jobs-scraper`, and the fact that we let `elasticsearch` automatically generate `_id` for us. In order to solve this issue I did the following changes:

1.  changed the `_id` to be manually set by us:

- Each jobs index will use job's build id for its id.
- Each steps index will use a hash of `(job_build_id, step.name)` .
- Each usage index will use job's build id.
Each of the above should be unique per index.

2.  changed the bulk actions to "update"

This way, `elasticsearch` will not create duplicated documents in the same index as they have the same `_id` 