### PR TITLE
NO-ISSUE: Sort documents by id in ascending order

### DIFF
--- a/src/elasticsearch_cleanup/consts.py
+++ b/src/elasticsearch_cleanup/consts.py
@@ -1,5 +1,14 @@
 from typing import Any, Final
 
 OPENSEARCH_QUERY_ALL_INDEX_DOCUMENTS: Final[dict[str, Any]] = {
-    "query": {"match_all": {}}
+    "query": {"match_all": {}},
+    "sort": [
+        {
+            "_script": {
+                "type": "number",
+                "script": {"source": "doc['_id'].value.length()", "lang": "painless"},
+                "order": "asc",
+            }
+        }
+    ],
 }


### PR DESCRIPTION
The `Scraper` previously relied on Elasticsearch's auto-generated `_id` for document identification. Due to complications arising from parallel scraping, this approach led to the indexing of duplicate documents. To address this, I modified the `_id` assignment for newly scraped documents to use our own identifier, which is based on the `MurmurHash 3`. Furthermore, I adjusted the bulk actions to utilize the `update` method. However, it's important to note that historical documents still retain the Elasticsearch auto-generated `_id`, characterized by strings of letters and dashes. When using the `elasticsearch-cleanup` process to remove duplicates, it can delete the newer documents with the `MurmurHash 3` based `_id`. This happens because the cleanup process simply deletes the second instance of any duplicate it finds, potentially leading to recurring duplicates upon subsequent indexing by the `Scraper`. To prevent this issue, I changed the documents retrieved by `elasticsearch`. By sorting documents in ascending order of `_id` length, we ensure `elasticsearch-cleanup` will encounter new documents before therefore remove the old ones.
