### PR TITLE
MGMT-19125: fix tekton pipeline on push

### DIFF
--- a/.tekton/prow-jobs-scraper-saas-main-push.yaml
+++ b/.tekton/prow-jobs-scraper-saas-main-push.yaml
@@ -251,8 +251,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -278,8 +276,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST


### PR DESCRIPTION
The tekton pipelines are used by konflux, and the one for push events is broken.
It tries to use a named result that does not exist, the pipeline for pull does not have this problem.