### PR TITLE
NO-ISSUE: Fix containers failing due to jobs with invalid equinix metadata

### DIFF
--- a/src/prowjobsscraper/equinix_metadata.py
+++ b/src/prowjobsscraper/equinix_metadata.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Final
 
@@ -47,6 +48,12 @@ class EquinixMetadataExtractor:
             logger.debug("Equinix metadata are missing from %s: %s", metadata_path, e)
 
         if raw_metadata:
-            job.equinixMetadata = EquinixMetadata.parse_raw(raw_metadata)
+            try:
+                job.equinixMetadata = EquinixMetadata.parse_raw(raw_metadata)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to decode Equinix metadata for job {job.spec.job}: {e}"
+                )
+
         else:
             logger.info("No equinix metadata found for job %s", job)


### PR DESCRIPTION
This job caused the failure - https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-cluster-etcd-operator-release-4.17-periodics-e2e-metal-assisted-four-node-scaling/1908675158332149760/artifacts/e2e-metal-assisted-four-node-scaling/baremetalds-packet-gather-metadata/artifacts/equinix-metadata.json